### PR TITLE
Copter: add gimbal and camera to iris

### DIFF
--- a/ardupilot_gz_bringup/config/iris.rviz
+++ b/ardupilot_gz_bringup/config/iris.rviz
@@ -1,14 +1,13 @@
 Panels:
   - Class: rviz_common/Displays
-    Help Height: 78
+    Help Height: 36
     Name: Displays
     Property Tree Widget:
       Expanded:
         - /Global Options1
-        - /RobotModel1
-        - /Odometry1
+        - /Image1/Topic1
       Splitter Ratio: 0.5
-    Tree Height: 510
+    Tree Height: 253
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -71,10 +70,20 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
+        gimbal_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         imu_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
+        roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         rotor_0:
           Alpha: 1
           Show Axes: false
@@ -95,6 +104,11 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
+        tilt_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
       Mass Properties:
         Inertia: false
         Mass: false
@@ -103,6 +117,79 @@ Visualization Manager:
       Update Interval: 0
       Value: true
       Visual Enabled: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base_link:
+          Value: true
+        gimbal_link:
+          Value: true
+        imu_link:
+          Value: true
+        iris:
+          Value: true
+        iris/base_link:
+          Value: true
+        iris/gimbal_link:
+          Value: true
+        iris/imu_link:
+          Value: true
+        iris/odom:
+          Value: true
+        iris/roll_link:
+          Value: true
+        iris/rotor_0:
+          Value: true
+        iris/rotor_1:
+          Value: true
+        iris/rotor_2:
+          Value: true
+        iris/rotor_3:
+          Value: true
+        iris/tilt_link:
+          Value: true
+        roll_link:
+          Value: true
+        rotor_0:
+          Value: true
+        rotor_1:
+          Value: true
+        rotor_2:
+          Value: true
+        rotor_3:
+          Value: true
+        tilt_link:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        iris/odom:
+          iris:
+            iris/base_link:
+              {}
+            iris/gimbal_link:
+              {}
+            iris/imu_link:
+              {}
+            iris/roll_link:
+              {}
+            iris/rotor_0:
+              {}
+            iris/rotor_1:
+              {}
+            iris/rotor_2:
+              {}
+            iris/rotor_3:
+              {}
+            iris/tilt_link:
+              {}
+      Update Interval: 0
+      Value: true
     - Angle Tolerance: 0.10000000149011612
       Class: rviz_default_plugins/Odometry
       Covariance:
@@ -121,7 +208,7 @@ Visualization Manager:
           Value: true
         Value: true
       Enabled: true
-      Keep: 100
+      Keep: 500
       Name: Odometry
       Position Tolerance: 0.10000000149011612
       Shape:
@@ -141,6 +228,20 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /iris/odometry
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: true
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /camera/image
       Value: true
   Enabled: true
   Global Options:
@@ -214,7 +315,9 @@ Window Geometry:
   Height: 801
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000001630000029bfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006200fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002c0000029b000000e300fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000029bfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002c0000029b000000c600fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004af0000003efc0100000002fb0000000800540069006d00650100000000000004af0000023d00fffffffb0000000800540069006d006501000000000000045000000000000000000000034b0000029b00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001630000029bfc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006200fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002c00000170000000e300fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d006100670065010000019d0000012a0000003000ffffff000000010000010f0000029bfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002c0000029b000000c600fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004af0000003efc0100000002fb0000000800540069006d00650100000000000004af0000023d00fffffffb0000000800540069006d006501000000000000045000000000000000000000034b0000029b00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:

--- a/ardupilot_gz_bringup/config/iris_bridge.yaml
+++ b/ardupilot_gz_bringup/config/iris_bridge.yaml
@@ -24,4 +24,13 @@
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
-
+- ros_topic_name: "/camera/image"
+  gz_topic_name: "/world/demo/model/iris/link/tilt_link/sensor/camera/image"
+  ros_type_name: "sensor_msgs/msg/Image"
+  gz_type_name: "gz.msgs.Image"
+  direction: GZ_TO_ROS
+- ros_topic_name: "/camera/camera_info"
+  gz_topic_name: "/world/demo/model/iris/link/tilt_link/sensor/camera/camera_info"
+  ros_type_name: "sensor_msgs/msg/CameraInfo"
+  gz_type_name: "gz.msgs.CameraInfo"
+  direction: GZ_TO_ROS

--- a/ardupilot_gz_bringup/launch/bringup_iris.launch.py
+++ b/ardupilot_gz_bringup/launch/bringup_iris.launch.py
@@ -52,6 +52,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     """Generate a launch description for a iris quadcopter."""
     pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
+    pkg_ardupilot_gazebo = get_package_share_directory("ardupilot_gazebo")
 
     # Include component launch files.
     iris_gz = IncludeLaunchDescription(
@@ -100,10 +101,9 @@ def generate_launch_description():
             "instance": "0",
             "uartC": "uart:./dev/ttyROS1",
             "defaults": os.path.join(
-                pkg_ardupilot_sitl,
+                pkg_ardupilot_gazebo,
                 "config",
-                "default_params",
-                "gazebo-iris.parm",
+                "gazebo-iris-gimbal.parm",
             )
             + ","
             + os.path.join(

--- a/ardupilot_gz_bringup/launch/iris.launch.py
+++ b/ardupilot_gz_bringup/launch/iris.launch.py
@@ -48,15 +48,23 @@ def generate_launch_description():
     """Generate a launch description for a iris quadcopter."""
     pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
     pkg_project_gazebo = get_package_share_directory("ardupilot_gz_gazebo")
-    # pkg_project_description = get_package_share_directory(
-    #       'ardupilot_gz_description')
     pkg_ros_gz_sim = get_package_share_directory("ros_gz_sim")
-
     pkg_ardupilot_gazebo = get_package_share_directory("ardupilot_gazebo")
+
+    # Ensure `SDF_PATH` is populated as `sdformat_urdf` uses this rather
+    # than `GZ_SIM_RESOURCE_PATH` to locate resources.
+    if "GZ_SIM_RESOURCE_PATH" in os.environ:
+        gz_sim_resource_path = os.environ["GZ_SIM_RESOURCE_PATH"]
+
+        if "SDF_PATH" in os.environ:
+            sdf_path = os.environ["SDF_PATH"]
+            os.environ["SDF_PATH"] = sdf_path + ":" + gz_sim_resource_path
+        else:
+            os.environ["SDF_PATH"] = gz_sim_resource_path
 
     # Load the SDF file from "description" package
     sdf_file = os.path.join(
-        pkg_ardupilot_gazebo, "models", "iris_with_standoffs", "model.sdf"
+        pkg_ardupilot_gazebo, "models", "iris_with_gimbal", "model.sdf"
     )
     with open(sdf_file, "r") as infp:
         robot_desc = infp.read()

--- a/ardupilot_gz_gazebo/worlds/iris.sdf
+++ b/ardupilot_gz_gazebo/worlds/iris.sdf
@@ -50,10 +50,29 @@
 
     <model name="iris">
       <pose>0 0 0.194923 0 0 0</pose>
+
       <include merge="true">
         <uri>package://ardupilot_gazebo/models/iris_with_standoffs</uri>
         <name>iris</name>
       </include>
+
+      <include merge="true">
+        <uri>package://ardupilot_gazebo/models/gimbal_small_2d</uri>
+        <name>gimbal</name>
+        <pose>0 -0.01 -0.11 1.57 0 1.57</pose>
+      </include>
+
+      <joint name="gimbal_joint" type="revolute">
+        <parent>base_link</parent>
+        <child>gimbal_link</child>
+        <axis>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+          </limit>
+          <xyz>0 0 1</xyz>
+        </axis>
+      </joint>
 
       <plugin
         filename="gz-sim-joint-state-publisher-system"
@@ -233,8 +252,23 @@
         <joint_name>rotor_3_joint</joint_name>
       </plugin>
 
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>roll_joint</joint_name>
+        <topic>/gimbal/cmd_roll</topic>
+        <p_gain>2</p_gain>
+      </plugin>
+      <plugin
+        filename="gz-sim-joint-position-controller-system"
+        name="gz::sim::systems::JointPositionController">
+        <joint_name>tilt_joint</joint_name>
+        <topic>/gimbal/cmd_tilt</topic>
+        <p_gain>2</p_gain>
+      </plugin>
+
       <plugin name="ArduPilotPlugin"
-        filename="libArduPilotPlugin">
+        filename="ArduPilotPlugin">
         <fdm_addr>127.0.0.1</fdm_addr>
         <fdm_port_in>9002</fdm_port_in>
         <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
@@ -316,6 +350,28 @@
           <cmd_max>2.5</cmd_max>
           <cmd_min>-2.5</cmd_min>
           <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
+        </control>
+
+        <control channel="4">
+          <jointName>roll_joint</jointName>
+          <multiplier>3.14159265</multiplier>
+          <offset>-0.5</offset>
+          <servo_min>1100</servo_min>
+          <servo_max>1900</servo_max>
+          <type>COMMAND</type>
+          <cmd_topic>/gimbal/cmd_roll</cmd_topic>
+          <p_gain>3</p_gain>
+        </control>
+
+        <control channel="5">
+          <jointName>tilt_joint</jointName>
+          <multiplier>3.14159265</multiplier>
+          <offset>-0.5</offset>
+          <servo_min>1100</servo_min>
+          <servo_max>1900</servo_max>
+          <type>COMMAND</type>
+          <cmd_topic>/gimbal/cmd_tilt</cmd_topic>
+          <p_gain>3</p_gain>
         </control>
 
     </plugin>

--- a/ros2_gz.repos
+++ b/ros2_gz.repos
@@ -1,0 +1,37 @@
+repositories:
+  ardupilot:
+    type: git
+    url: https://github.com/srmainwaring/ardupilot.git
+    version: wip/dds-launch-gz
+  ardupilot_gazebo:
+    type: git
+    url: https://github.com/srmainwaring/ardupilot_gazebo-1.git
+    version: wips/wip-colcon-pkg-sdf-mods
+  ardupilot_gz:
+    type: git
+    url: https://github.com/srmainwaring/ardupilot_gz.git
+    version: wips/wip-iris-camera
+  gps_umd:
+    type: git
+    url: https://github.com/swri-robotics/gps_umd.git
+    version: ros2-devel
+  micro_ros_agent:
+    type: git
+    url: https://github.com/srmainwaring/micro-ROS-Agent.git
+    version: cmake-macos
+  micro_ros_msgs:
+    type: git
+    url: https://github.com/micro-ROS/micro_ros_msgs.git
+    version: humble
+  microxrcedds_gen:
+    type: git
+    url: https://github.com/eProsima/Micro-XRCE-DDS-Gen.git
+    version: master
+  ros_gz:
+    type: git
+    url: https://github.com/gazebosim/ros_gz.git
+    version: ros2
+  sdformat_urdf:
+    type: git
+    url: https://github.com/srmainwaring/sdformat_urdf.git
+    version: srmainwaring/humble-garden


### PR DESCRIPTION
Update launch files to use the version of the Iris with the camera and gimbal.

## Related issues

- https://github.com/ArduPilot/ROS2_Tools/issues/2

## Details

- Use modified versions of the `ardupilot_gazebo` models using `package://` URI's rather than the `model://` versions.
- Update the bridge yaml to map the camera stream to ROS 2.
- Update `rviz` config to display the image.
- Update the launch files to use the parameters for the gimbal variant of the iris.
- Update the launch files to  set the `SDF_PATH` correctly for `sdformat_urdf`.
- Add the gimbal to the iris world file.
- Add a `ros2_gz.repos` file detailing all source dependencies.

## Testing

Figure: iris with gimbal and camera in Gazebo streaming sensor data to ROS 2.

![ardupilot-gz-iris-camera](https://user-images.githubusercontent.com/24916364/232487977-28d5cb36-99de-457b-a336-a54dc2ebdf6d.jpg)