### PR TITLE
Tools: upstream changes to ardupilot_sitl

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ colcon build --cmake-args -DBUILD_TESTING=ON
 
 ```bash
 source ./install/setup.bash
-colcon test --packages-select ardupilot_dds_sitl ardupilot_dds_tests ardupilot_gazebo ardupilot_gz_applications ardupilot_gz_description ardupilot_gz_gazebo ardupilot_gz_bringup 
+colcon test --packages-select ardupilot_sitl ardupilot_dds_tests ardupilot_gazebo ardupilot_gz_applications ardupilot_gz_description ardupilot_gz_gazebo ardupilot_gz_bringup 
 colcon test-result --all --verbose
 ```
 

--- a/ardupilot_gz_bringup/launch/robots/iris.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris.launch.py
@@ -16,7 +16,7 @@
 """
 Launch an iris quadcopter in Gazebo and Rviz.
 
-ros2 launch ardupilot_dds_tests bringup_sitl_dds.launch.py
+ros2 launch ardupilot_sitl sitl_dds.launch.py
 tty0:=./dev/ttyROS0
 tty1:=./dev/ttyROS1
 refs:=$(ros2 pkg prefix ardupilot_sitl)
@@ -57,14 +57,14 @@ def generate_launch_description():
     pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
 
     # Include component launch files.
-    bringup_sitl_dds = IncludeLaunchDescription(
+    sitl_dds = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
                 PathJoinSubstitution(
                     [
-                        FindPackageShare("ardupilot_dds_tests"),
+                        FindPackageShare("ardupilot_sitl"),
                         "launch",
-                        "bringup_sitl_dds.launch.py",
+                        "sitl_dds.launch.py",
                     ]
                 ),
             ]
@@ -160,7 +160,7 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
-            bringup_sitl_dds,
+            sitl_dds,
             robot_state_publisher,
             bridge,
         ]

--- a/ardupilot_gz_description/models/README.md
+++ b/ardupilot_gz_description/models/README.md
@@ -1,1 +1,1 @@
-# Placeholder for `ardupilot_gz_description` models.
+### Placeholder for `ardupilot_gz_description` models.


### PR DESCRIPTION
Incorporate launch file changes in upstream packages.

- Launch files moved from `ardupilot_dds_tests` to `ardupilit_sitl`.
- `bringup_sitl_dds.launch.py` renamed to `sitl_dds.launch.py`.
- Update docs.
