### PR TITLE
Copter: use udp transport in launch

### DIFF
--- a/ardupilot_gz_bringup/config/iris_bridge.yaml
+++ b/ardupilot_gz_bringup/config/iris_bridge.yaml
@@ -1,77 +1,77 @@
 ---
-- ros_topic_name: "/clock"
+- ros_topic_name: "clock"
   gz_topic_name: "/clock"
   ros_type_name: "rosgraph_msgs/msg/Clock"
   gz_type_name: "gz.msgs.Clock"
   direction: GZ_TO_ROS
-- ros_topic_name: "/joint_states"
+- ros_topic_name: "joint_states"
   gz_topic_name: "/world/map/model/iris/joint_state"
   ros_type_name: "sensor_msgs/msg/JointState"
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
-- ros_topic_name: "/odometry"
+- ros_topic_name: "odometry"
   gz_topic_name: "/model/iris/odometry"
   ros_type_name: "nav_msgs/msg/Odometry"
   gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
-- ros_topic_name: "/tf"
+- ros_topic_name: "tf"
   gz_topic_name: "/model/iris/pose"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
-- ros_topic_name: "/tf_static"
+- ros_topic_name: "tf_static"
   gz_topic_name: "/model/iris/pose_static"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
-- ros_topic_name: "/camera/image"
+- ros_topic_name: "camera/image"
   gz_topic_name: "/world/map/model/iris/link/tilt_link/sensor/camera/image"
   ros_type_name: "sensor_msgs/msg/Image"
   gz_type_name: "gz.msgs.Image"
   direction: GZ_TO_ROS
-- ros_topic_name: "/camera/camera_info"
+- ros_topic_name: "camera/camera_info"
   gz_topic_name: "/world/map/model/iris/link/tilt_link/sensor/camera/camera_info"
   ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "gz.msgs.CameraInfo"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "/air_pressure"
+- ros_topic_name: "air_pressure"
   gz_topic_name: "/world/map/model/iris/link/base_link/sensor/air_pressure_sensor/air_pressure"
   ros_type_name: "sensor_msgs/msg/FluidPressure"
   gz_type_name: "gz.msgs.FluidPressure"
   direction: GZ_TO_ROS
 
-# - ros_topic_name: "/air_speed"
+# - ros_topic_name: "air_speed"
 #   gz_topic_name: "/world/map/model/iris/link/base_link/sensor/air_speed_sensor/air_speed"
 #   ros_type_name: "geometry_msgs/msg/Vector3Stamped"
 #   gz_type_name: "gz.msgs.AirSpeedSensor"
 #   direction: GZ_TO_ROS
 
-# - ros_topic_name: "/altimeter"
+# - ros_topic_name: "altimeter"
 #   gz_topic_name: "/world/map/model/iris/link/base_link/sensor/altimeter_sensor/altimeter"
 #   ros_type_name: "geometry_msgs/msg/Vector3Stamped"
 #   gz_type_name: "gz.msgs.Altimeter"
 #   direction: GZ_TO_ROS
 
-- ros_topic_name: "/imu"
+- ros_topic_name: "imu"
   gz_topic_name: "/world/map/model/iris/link/imu_link/sensor/imu_sensor/imu"
   ros_type_name: "sensor_msgs/msg/Imu"
   gz_type_name: "gz.msgs.IMU"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "/magnetometer"
+- ros_topic_name: "magnetometer"
   gz_topic_name: "/world/map/model/iris/link/base_link/sensor/magnetometer_sensor/magnetometer"
   ros_type_name: "sensor_msgs/msg/MagneticField"
   gz_type_name: "gz.msgs.Magnetometer"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "/navsat"
+- ros_topic_name: "navsat"
   gz_topic_name: "/world/map/model/iris/link/base_link/sensor/navsat_sensor/navsat"
   ros_type_name: "sensor_msgs/msg/NavSatFix"
   gz_type_name: "gz.msgs.NavSat"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "/battery"
+- ros_topic_name: "battery"
   gz_topic_name: "/model/iris/battery/linear_battery/state"
   ros_type_name: "sensor_msgs/msg/BatteryState"
   gz_type_name: "gz.msgs.BatteryState"

--- a/ardupilot_gz_bringup/launch/robots/iris.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris.launch.py
@@ -16,23 +16,21 @@
 """
 Launch an iris quadcopter in Gazebo and Rviz.
 
-ros2 launch ardupilot_sitl sitl_dds.launch.py
-tty0:=./dev/ttyROS0
-tty1:=./dev/ttyROS1
+ros2 launch ardupilot_sitl sitl_dds_udp.launch.py
+transport:=udp4
 refs:=$(ros2 pkg prefix ardupilot_sitl)
       /share/ardupilot_sitl/config/dds_xrce_profile.xml
-baudrate:=115200 device:=./dev/ttyROS0
+port:=2019
 synthetic_clock:=True
-wipe:=True
+wipe:=False
 model:=json
 speedup:=1
 slave:=0
 instance:=0
-uartC:=uart:./dev/ttyROS1
 defaults:=$(ros2 pkg prefix ardupilot_sitl)
           /share/ardupilot_sitl/config/default_params/gazebo-iris.parm,
           $(ros2 pkg prefix ardupilot_sitl)
-          /share/ardupilot_sitl/config/default_params/dds.parm
+          /share/ardupilot_sitl/config/default_params/dds_udp.parm
 sim_address:=127.0.0.1
 master:=tcp:127.0.0.1:5760
 sitl:=127.0.0.1:5501
@@ -64,14 +62,13 @@ def generate_launch_description():
                     [
                         FindPackageShare("ardupilot_sitl"),
                         "launch",
-                        "sitl_dds.launch.py",
+                        "sitl_dds_udp.launch.py",
                     ]
                 ),
             ]
         ),
         launch_arguments={
-            "tty0": "./dev/ttyROS0",
-            "tty1": "./dev/ttyROS1",
+            "transport": "udp4",
             "refs": PathJoinSubstitution(
                 [
                     FindPackageShare("ardupilot_sitl"),
@@ -79,15 +76,13 @@ def generate_launch_description():
                     "dds_xrce_profile.xml",
                 ]
             ),
-            "baudrate": "115200",
-            "device": "./dev/ttyROS0",
+            "port": "2019",
             "synthetic_clock": "True",
-            "wipe": "True",
+            "wipe": "False",
             "model": "json",
             "speedup": "1",
             "slave": "0",
             "instance": "0",
-            "uartC": "uart:./dev/ttyROS1",
             "defaults": os.path.join(
                 pkg_ardupilot_gazebo,
                 "config",
@@ -98,7 +93,7 @@ def generate_launch_description():
                 pkg_ardupilot_sitl,
                 "config",
                 "default_params",
-                "dds.parm",
+                "dds_udp.parm",
             ),
             "sim_address": "127.0.0.1",
             "master": "tcp:127.0.0.1:5760",

--- a/ardupilot_gz_gazebo/worlds/iris_runway.sdf
+++ b/ardupilot_gz_gazebo/worlds/iris_runway.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.8">
+<sdf version="1.9">
   <world name="map">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>

--- a/ros2_gz_macos.repos
+++ b/ros2_gz_macos.repos
@@ -11,9 +11,17 @@ repositories:
     type: git
     url: https://github.com/ArduPilot/ardupilot_gz.git
     version: main
+  gps_umd:
+    type: git
+    url: https://github.com/swri-robotics/gps_umd.git
+    version: ros2-devel
   micro_ros_agent:
     type: git
-    url: https://github.com/micro-ROS/micro-ROS-Agent.git
+    url: https://github.com/srmainwaring/micro-ROS-Agent.git
+    version: humble-macos
+  micro_ros_msgs:
+    type: git
+    url: https://github.com/micro-ROS/micro_ros_msgs.git
     version: humble
   ros_gz:
     type: git
@@ -21,5 +29,5 @@ repositories:
     version: ros2
   sdformat_urdf:
     type: git
-    url: https://github.com/ros/sdformat_urdf.git
-    version: ros2
+    url: https://github.com/srmainwaring/sdformat_urdf.git
+    version: ros2-macos


### PR DESCRIPTION
Update the launch script for the iris quadcopter example to use UDP transport.

- Use UDP transport as default (instead of serial with virtual ports).
- Update config file (remove leading `/` so ROS topics are not all in global namespace).
- Update dependencies to use ArduPilot versions of repos where available.

## Dependencies

- https://github.com/ArduPilot/ardupilot/pull/23703