### PR TITLE
Tools: update ros_gz dependency to use humble branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mkdir -p ~/ros2_ws/src && cd ~/ros2_ws/src
 
 ```bash
 cd ~/ros2_ws/src
-wget https://raw.githubusercontent.com/srmainwaring/ardupilot_gz/main/ros2_gz.repos
+wget https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/main/ros2_gz.repos
 vcs import --recursive < ros2_gz.repos
 ```
 
@@ -51,7 +51,7 @@ cd ~/ros2_ws
 source /opt/ros/humble/setup.bash
 sudo apt update
 rosdep update
-rosdep install --rosdistro humble --from-paths src -i -r -y
+rosdep install --rosdistro $ROS_DISTRO --from-paths src -i -r -y
 ```
 
 #### 5. Build

--- a/ros2_gz.repos
+++ b/ros2_gz.repos
@@ -18,7 +18,7 @@ repositories:
   ros_gz:
     type: git
     url: https://github.com/gazebosim/ros_gz.git
-    version: ros2
+    version: humble
   sdformat_urdf:
     type: git
     url: https://github.com/ros/sdformat_urdf.git

--- a/ros2_gz_macos.repos
+++ b/ros2_gz_macos.repos
@@ -26,7 +26,7 @@ repositories:
   ros_gz:
     type: git
     url: https://github.com/gazebosim/ros_gz.git
-    version: ros2
+    version: humble
   sdformat_urdf:
     type: git
     url: https://github.com/srmainwaring/sdformat_urdf.git


### PR DESCRIPTION
The `ros2` branch of `ros_gz` now depends on `iron`.