### PR TITLE
Tools: Add pre-commit with black and xmllint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  -   repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.2.0
+      hooks:
+        -   id: trailing-whitespace
+        -   id: end-of-file-fixer
+        -   id: mixed-line-ending
+            name: Check line ending character (LF)
+            args: ["--fix=lf"]
+        -   id: check-added-large-files
+        -   id: check-merge-conflict
+        -   id: check-xml
+        -   id: check-yaml
+
+  -   repo: https://github.com/lsst-ts/pre-commit-xmllint
+      rev: v1.0.0
+      hooks:
+        - id: format-xmllint
+
+  -   repo: https://github.com/psf/black
+      rev: 23.1.0
+      hooks:
+        - id: black

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ colcon build --cmake-args -DBUILD_TESTING=ON
 
 ```bash
 source ./install/setup.bash
-colcon test --packages-select ardupilot_sitl ardupilot_dds_tests ardupilot_gazebo ardupilot_gz_applications ardupilot_gz_description ardupilot_gz_gazebo ardupilot_gz_bringup 
+colcon test --packages-select ardupilot_sitl ardupilot_dds_tests ardupilot_gazebo ardupilot_gz_applications ardupilot_gz_description ardupilot_gz_gazebo ardupilot_gz_bringup
 colcon test-result --all --verbose
 ```
 
@@ -133,7 +133,7 @@ git clone https://github.com/swri-robotics/gps_umd.git -b ros2-devel
 ```
 
 When building from source add `COLCON_IGNORE` to `gpsd_client` as
-this package is not required and will not build on macOS. 
+this package is not required and will not build on macOS.
 
 ### 2. `sdformat_urdf`
 
@@ -177,4 +177,3 @@ export SDF_PATH=$GZ_SIM_RESOURCE_PATH
 
 This is assigned in the `iris.launch.py` file as `SDF_PATH` is not usually set
 by the `ament` environment hooks.
-

--- a/ardupilot_gz_application/.flake8
+++ b/ardupilot_gz_application/.flake8
@@ -2,9 +2,8 @@
 # Match black line length (default 88).
 max-line-length = 88
 # Match black configuration where there are conflicts.
-extend-ignore = 
+extend-ignore =
   # Q000: Double quotes found but single quotes preferred
   Q000,
   # W503: Line break before binary operator
   W503
-

--- a/ardupilot_gz_application/package.xml
+++ b/ardupilot_gz_application/package.xml
@@ -6,15 +6,11 @@
   <description>Application code for `ardupilot_gz`.</description>
   <maintainer email="rhys.mainwaring@me.com">Rhys Mainwaring</maintainer>
   <license>GPL-3.0</license>
-
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>
 </package>
-

--- a/ardupilot_gz_bringup/.flake8
+++ b/ardupilot_gz_bringup/.flake8
@@ -2,9 +2,8 @@
 # Match black line length (default 88).
 max-line-length = 88
 # Match black configuration where there are conflicts.
-extend-ignore = 
+extend-ignore =
   # Q000: Double quotes found but single quotes preferred
   Q000,
   # W503: Line break before binary operator
   W503
-

--- a/ardupilot_gz_bringup/package.xml
+++ b/ardupilot_gz_bringup/package.xml
@@ -6,20 +6,15 @@
   <description>Launch files for `ardupilot_gz`.</description>
   <maintainer email="rhys.mainwaring@me.com">Rhys Mainwaring</maintainer>
   <license>GPL-3.0</license>
-
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
-
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
-
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>
 </package>
-

--- a/ardupilot_gz_description/.flake8
+++ b/ardupilot_gz_description/.flake8
@@ -2,9 +2,8 @@
 # Match black line length (default 88).
 max-line-length = 88
 # Match black configuration where there are conflicts.
-extend-ignore = 
+extend-ignore =
   # Q000: Double quotes found but single quotes preferred
   Q000,
   # W503: Line break before binary operator
   W503
-

--- a/ardupilot_gz_description/hooks/ardupilot_gz_description.sh.in
+++ b/ardupilot_gz_description/hooks/ardupilot_gz_description.sh.in
@@ -1,2 +1,1 @@
 ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
-

--- a/ardupilot_gz_description/models/iris_with_lidar/model.config
+++ b/ardupilot_gz_description/models/iris_with_lidar/model.config
@@ -9,7 +9,7 @@
     <name>Pedro Fuoco</name>
     <email>pedrofuoco6@gmail.com</email>
   </author>
-  
+
   <maintainer email="pedrofuoco6@gmail.com">Pedro Fuoco</maintainer>
 
   <description>

--- a/ardupilot_gz_description/models/iris_with_lidar/model.sdf
+++ b/ardupilot_gz_description/models/iris_with_lidar/model.sdf
@@ -310,7 +310,7 @@
           </box>
         </geometry>
       </collision>
-      
+
       <visual name="visual">
         <geometry>
           <box>
@@ -320,7 +320,7 @@
       </visual>
 
       <sensor name='gpu_lidar' type='gpu_lidar'>
-        <ignition_frame_id>iris/base_scan</ignition_frame_id> 
+        <ignition_frame_id>iris/base_scan</ignition_frame_id>
         <pose>0 0 0 0 0 0</pose>
         <topic>lidar</topic>
         <update_rate>10</update_rate>
@@ -360,7 +360,7 @@
         </limit>
         <dynamics>
           <damping>1</damping>
-        </dynamics>      
+        </dynamics>
       </axis>
     </joint>
 

--- a/ardupilot_gz_description/package.xml
+++ b/ardupilot_gz_description/package.xml
@@ -6,13 +6,10 @@
   <description>Model descriptions for `ardupilot_gz`.</description>
   <maintainer email="rhys.mainwaring@me.com">Rhys Mainwaring</maintainer>
   <license>GPL-3.0</license>
-
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ardupilot_gz_gazebo/.flake8
+++ b/ardupilot_gz_gazebo/.flake8
@@ -2,9 +2,8 @@
 # Match black line length (default 88).
 max-line-length = 88
 # Match black configuration where there are conflicts.
-extend-ignore = 
+extend-ignore =
   # Q000: Double quotes found but single quotes preferred
   Q000,
   # W503: Line break before binary operator
   W503
-

--- a/ardupilot_gz_gazebo/package.xml
+++ b/ardupilot_gz_gazebo/package.xml
@@ -6,9 +6,7 @@
   <description>Gazebo specific systems for `ardupilot_gz`.</description>
   <maintainer email="rhys.mainwaring@me.com">Rhys Mainwaring</maintainer>
   <license>GPL-3.0</license>
-
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <!-- <test_depend>ament_lint_common</test_depend> -->
   <!-- <test_depend>ament_cmake_clang_format</test_depend> -->
@@ -24,9 +22,7 @@
   <test_depend>ament_cmake_pycodestyle</test_depend>
   <!-- <test_depend>ament_cmake_uncrustify</test_depend> -->
   <test_depend>ament_cmake_xmllint</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>
 </package>
-

--- a/ardupilot_gz_gazebo/worlds/iris_maze.sdf
+++ b/ardupilot_gz_gazebo/worlds/iris_maze.sdf
@@ -91,7 +91,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_1'>
         <pose>-10 -10 0 0 0 0</pose>
         <collision name='Wall_1_Collision'>
@@ -137,7 +137,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_3'>
         <pose>-10 10 0 0 0 0</pose>
         <collision name='Wall_3_Collision'>
@@ -160,7 +160,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_4'>
         <pose>-7 -7 0 0 0 0</pose>
         <collision name='Wall_4_Collision'>
@@ -183,7 +183,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_5'>
         <pose degrees="true">-7 -7 0 0 0 90</pose>
         <collision name='Wall_5_Collision'>
@@ -206,7 +206,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_6'>
         <pose>-4 -4 0 0 0 0</pose>
         <collision name='Wall_6_Collision'>
@@ -229,7 +229,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_7'>
         <pose degrees="true">-4 -4 0 0 0 90</pose>
         <collision name='Wall_7_Collision'>
@@ -252,7 +252,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_8'>
         <pose>-1 -1 0 0 0 0</pose>
         <collision name='Wall_8_Collision'>
@@ -275,7 +275,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_9'>
         <pose degrees="true">-1 -1 0 0 0 90</pose>
         <collision name='Wall_9_Collision'>
@@ -298,7 +298,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_10'>
         <pose degrees="true">-4 7 0 0 0 90</pose>
         <collision name='Wall_10_Collision'>
@@ -321,7 +321,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_11'>
         <pose>-1 4 0 0 0 0</pose>
         <collision name='Wall_11_Collision'>
@@ -344,7 +344,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_12'>
         <pose>2 7 0 0 0 0</pose>
         <collision name='Wall_12_Collision'>
@@ -367,7 +367,7 @@
           </material>
         </visual>
       </link>
-      
+
       <link name='Wall_13'>
         <pose degrees="true">5 2 0 0 0 90</pose>
         <collision name='Wall_13_Collision'>
@@ -431,6 +431,6 @@
       <name>iris</name>
       <pose degrees="true">0 0 0.194923 0 0 90</pose>
     </include>
-    
+
   </world>
 </sdf>


### PR DESCRIPTION
Added pre-commit .yaml file with `black` and `xmllint` as well as some `pre-commit` hooks.

The pre-commit documentation recommends running this the first time to ensure that all the files in the repository are formatted correctly:
```bash
pre-commit run --all-files
```
So I will add a second commit to make the recommended changes