### PR TITLE
Copter: get lidar above iris

### DIFF
--- a/ardupilot_gz_description/models/iris_with_lidar/model.sdf
+++ b/ardupilot_gz_description/models/iris_with_lidar/model.sdf
@@ -293,7 +293,7 @@
 
 
     <link name="base_scan">
-      <pose>0 0 0.075 0 0 0</pose>
+      <pose>0 0 0.27 0 0 0</pose>
       <inertial>
         <mass>0.1</mass>
         <inertia>


### PR DESCRIPTION
A simple change to get the lidar on top of the iris instead of beneath it.
Before:
![lidar beneath iris](https://github.com/ArduPilot/ardupilot_gz/assets/62964137/1bea7b73-deba-4085-92d7-f220b061578d)
After:
![lidar above](https://github.com/ArduPilot/ardupilot_gz/assets/62964137/dc33c83d-59ee-4c72-b784-17d64884080e)

This stops the lidar data from detecting the Copter's landing gear, which was causing problems with `nav2`'s obstacle avoidance features. The costmap without it is now clean:

![costmap example](https://github.com/ArduPilot/ardupilot_gz/assets/62964137/7e572e9b-cd24-44d1-8a41-2132e3f234cc)

