### PR TITLE
Copter: default topic names

### DIFF
--- a/ardupilot_gz_bringup/config/iris_bridge.yaml
+++ b/ardupilot_gz_bringup/config/iris_bridge.yaml
@@ -14,12 +14,12 @@
   ros_type_name: "nav_msgs/msg/Odometry"
   gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
-- ros_topic_name: "tf"
+- ros_topic_name: "gz/tf"
   gz_topic_name: "/model/iris/pose"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
-- ros_topic_name: "tf_static"
+- ros_topic_name: "gz/tf_static"
   gz_topic_name: "/model/iris/pose_static"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"

--- a/ardupilot_gz_bringup/config/iris_lidar_bridge.yaml
+++ b/ardupilot_gz_bringup/config/iris_lidar_bridge.yaml
@@ -14,12 +14,12 @@
   ros_type_name: "nav_msgs/msg/Odometry"
   gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
-- ros_topic_name: "tf"
+- ros_topic_name: "gz/tf"
   gz_topic_name: "/model/iris/pose"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
-- ros_topic_name: "tf_static"
+- ros_topic_name: "gz/tf_static"
   gz_topic_name: "/model/iris/pose_static"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
@@ -31,7 +31,7 @@
   gz_type_name: "gz.msgs.IMU"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "laser/scan"
+- ros_topic_name: "scan"
   gz_topic_name: "/lidar"
   ros_type_name: "sensor_msgs/msg/LaserScan"
   gz_type_name: "gz.msgs.LaserScan"

--- a/ardupilot_gz_bringup/launch/robots/iris.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris.launch.py
@@ -131,10 +131,6 @@ def generate_launch_description():
         parameters=[
             {"robot_description": robot_desc},
         ],
-        remappings=[
-            ("/tf", "/ap/tf"),
-            ("/tf_static", "/ap/tf_static"),
-        ],
     )
 
     # Bridge.

--- a/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
@@ -134,10 +134,6 @@ def generate_launch_description():
         parameters=[
             {"robot_description": robot_desc},
         ],
-        remappings=[
-            ("/tf", "/ap/tf"),
-            ("/tf_static", "/ap/tf_static"),
-        ],
     )
 
     # Bridge.


### PR DESCRIPTION
The point of this PR is to eliminate some of the remappings necessary to work with this package, as discussed with @Ryanf55.

`/tf` and `/tf_static` should receive a `ros rep 105` compliant tf tree, in this case, the one coming from `robot_state_publisher`. 
Gazebo's tf tree can be renamed through the `ros_gz` yaml files instead of using another remap.
`/laser/scan` was renamed to `/scan` as this is used by both `cartographer` and `nav2`

https://github.com/ArduPilot/ardupilot_ros/pull/14
https://github.com/ArduPilot/ardupilot/pull/24819