### PR TITLE
Tools: support Gazebo Harmonic and Garden

### DIFF
--- a/ardupilot_gz_gazebo/CMakeLists.txt
+++ b/ardupilot_gz_gazebo/CMakeLists.txt
@@ -5,7 +5,11 @@ project(ardupilot_gz_gazebo)
 # Find dependencies.
 find_package(ament_cmake REQUIRED)
 
+# --------------------------------------------------------------------------- #
+# Find gz-sim and dependencies.
+
 find_package(gz-cmake3 REQUIRED)
+set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
 
 find_package(gz-plugin2 REQUIRED COMPONENTS register)
 set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
@@ -13,8 +17,21 @@ set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
 find_package(gz-common5 REQUIRED COMPONENTS profiler)
 set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
 
-find_package(gz-sim7 REQUIRED)
-set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
+# Garden (default)
+if("$ENV{GZ_VERSION}" STREQUAL "garden" OR NOT DEFINED "ENV{GZ_VERSION}")
+  gz_find_package(gz-sim7 REQUIRED)
+  set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
+
+  message(STATUS "Compiling against Gazebo Garden")
+# Harmonic
+elseif("$ENV{GZ_VERSION}" STREQUAL "harmonic")
+  gz_find_package(gz-sim8 REQUIRED)
+  set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
+
+  message(STATUS "Compiling against Gazebo Harmonic")
+else()  
+  message(FATAL_ERROR "Unsupported GZ_VERSION: $ENV{GZ_VERSION}")
+endif()
 
 # --------------------------------------------------------------------------- #
 #  Build.

--- a/ardupilot_gz_gazebo/package.xml
+++ b/ardupilot_gz_gazebo/package.xml
@@ -7,6 +7,17 @@
   <maintainer email="rhys.mainwaring@me.com">Rhys Mainwaring</maintainer>
   <license>GPL-3.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>gz-common5</depend>
+  <depend>gz-cmake3</depend>
+  <depend>gz-plugin2</depend>
+
+  <!-- Garden (default) -->
+  <depend condition="$GZ_VERSION == garden">gz-sim7</depend>
+  <depend condition="$GZ_VERSION == ''">gz-sim7</depend>
+  <!-- Harmonic -->
+  <depend condition="$GZ_VERSION == harmonic">gz-sim8</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <!-- <test_depend>ament_lint_common</test_depend> -->
   <!-- <test_depend>ament_cmake_clang_format</test_depend> -->


### PR DESCRIPTION
Add support for Gazebo Harmonic retaining the default support for Gazebo Garden. The version used is controlled by the environment variable GZ_VERSION which should be either garden or harmonic. If not set the default is to assume garden.

## Related

- https://github.com/ArduPilot/ardupilot_gazebo/pull/66
- https://github.com/ros/sdformat_urdf/pull/23