### PR TITLE
Remove micro_ros_agent launch argument referencing dds_xrce_profile.xml

### DIFF
--- a/ardupilot_gz_bringup/launch/robots/iris.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris.launch.py
@@ -18,8 +18,6 @@ Launch an iris quadcopter in Gazebo and Rviz.
 
 ros2 launch ardupilot_sitl sitl_dds_udp.launch.py
 transport:=udp4
-refs:=$(ros2 pkg prefix ardupilot_sitl)
-      /share/ardupilot_sitl/config/dds_xrce_profile.xml
 port:=2019
 synthetic_clock:=True
 wipe:=False
@@ -78,13 +76,6 @@ def generate_launch_description():
         ),
         launch_arguments={
             "transport": "udp4",
-            "refs": PathJoinSubstitution(
-                [
-                    FindPackageShare("ardupilot_sitl"),
-                    "config",
-                    "dds_xrce_profile.xml",
-                ]
-            ),
             "port": "2019",
             "synthetic_clock": "True",
             "wipe": "False",

--- a/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
@@ -18,8 +18,6 @@ Launch an iris quadcopter in Gazebo and Rviz.
 
 ros2 launch ardupilot_sitl sitl_dds_udp.launch.py
 transport:=udp4
-refs:=$(ros2 pkg prefix ardupilot_sitl)
-      /share/ardupilot_sitl/config/dds_xrce_profile.xml
 port:=2019
 synthetic_clock:=True
 wipe:=False
@@ -79,13 +77,6 @@ def generate_launch_description():
         ),
         launch_arguments={
             "transport": "udp4",
-            "refs": PathJoinSubstitution(
-                [
-                    FindPackageShare("ardupilot_sitl"),
-                    "config",
-                    "dds_xrce_profile.xml",
-                ]
-            ),
             "port": "2019",
             "synthetic_clock": "True",
             "wipe": "False",

--- a/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
@@ -18,8 +18,6 @@ Launch an wild thumper rover in Gazebo and Rviz.
 
 ros2 launch ardupilot_sitl sitl_dds_udp.launch.py
 transport:=udp4
-refs:=$(ros2 pkg prefix ardupilot_sitl)
-      /share/ardupilot_sitl/config/dds_xrce_profile.xml
 port:=2019
 synthetic_clock:=True
 wipe:=False
@@ -78,13 +76,6 @@ def generate_launch_description():
         ),
         launch_arguments={
             "transport": "udp4",
-            "refs": PathJoinSubstitution(
-                [
-                    FindPackageShare("ardupilot_sitl"),
-                    "config",
-                    "dds_xrce_profile.xml",
-                ]
-            ),
             "port": "2019",
             "command": "ardurover",
             "synthetic_clock": "True",


### PR DESCRIPTION
Remove the `ref:=...` argument from launch files. With https://github.com/ArduPilot/ardupilot/pull/27145 AP_DDS uses the micro-xrce-dds binary interface to create entities and the agent does not require a reference file to initialise the connection correctly.

### Dependencies

- https://github.com/ArduPilot/ardupilot/pull/27145