### PR TITLE
Copter: use 3DoF gimbal

### DIFF
--- a/ardupilot_gz_bringup/config/iris_bridge.yaml
+++ b/ardupilot_gz_bringup/config/iris_bridge.yaml
@@ -24,13 +24,14 @@
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
+
 - ros_topic_name: "camera/image"
-  gz_topic_name: "/world/map/model/iris/link/tilt_link/sensor/camera/image"
+  gz_topic_name: "/world/map/model/iris/link/pitch_link/sensor/camera/image"
   ros_type_name: "sensor_msgs/msg/Image"
   gz_type_name: "gz.msgs.Image"
   direction: GZ_TO_ROS
 - ros_topic_name: "camera/camera_info"
-  gz_topic_name: "/world/map/model/iris/link/tilt_link/sensor/camera/camera_info"
+  gz_topic_name: "/world/map/model/iris/link/pitch_link/sensor/camera/camera_info"
   ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "gz.msgs.CameraInfo"
   direction: GZ_TO_ROS


### PR DESCRIPTION
Change the Iris model to use the 3DoF gimbal.

### Dependencies

- https://github.com/ArduPilot/ardupilot_gazebo/pull/124

### Testing

Launch simulation

```bash
ros2 launch ardupilot_gz_bringup iris_runway.launch.py console:=True
```

and start a mavproxy interactive session to control:

```bash
mavproxy.py --master :14550
 
STABILIZE> mode guided
GUIDED> arm throttle
GUIDED> takeoff 2
GUIDED> Take Off started
GUIDED> rc 3 1500
GUIDED> circle
```

- The model appears correctly in Gazebo.
- The model appears correctly in rviz.
- The 3DoF gimbal links are visible in rviz2.
- The camera topic is relayed from Gazebo to ROS 2.
 
<img width="512" alt="iris-3dof-gimbal-rviz" src="https://github.com/user-attachments/assets/0e566ad2-b99b-4e98-8c78-a3d2b0f37990">

<img width="512" alt="iris-3dof-gimbal-gz" src="https://github.com/user-attachments/assets/344a960e-0d4f-4fb2-9c90-298a307c1612">

