### PR TITLE
Add branches for Jazzy and Humble with mergify support

### DIFF
--- a/.github/.mergify.yml
+++ b/.github/.mergify.yml
@@ -1,0 +1,36 @@
+---
+pull_request_rules:
+  - name: backport to jazzy at reviewers discretion
+    conditions:
+      - base=main
+      - label=backport-jazzy
+    actions:
+      backport:
+        branches:
+          - jazzy
+
+  - name: backport to humble at reviewers discretion
+    conditions:
+      - base=main
+      - label=backport-humble
+    actions:
+      backport:
+        branches:
+          - humble
+
+  - name: delete head branch after merge
+    conditions:
+      - merged
+    actions:
+      delete_head_branch:
+
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+      - author!=mergify
+    actions:
+      comment:
+        message: This pull request is in conflict. Could you fix it @{{author}}?
+
+# TODO enable automatic merge of backports
+# https://docs.mergify.com/workflow/actions/backport/#combining-automatic-merge

--- a/README.md
+++ b/README.md
@@ -33,9 +33,21 @@ mkdir -p ~/ros2_ws/src
 
 #### 2. Get the project source
 
+By default, `ardupilot_gz` uses the `main` branch for ROS 2 `rolling` development.
+We also maintain stable branches for LTS ROS distributions.
+Be sure to check out the appropriate branch.
+
 ```bash
 cd ~/ros2_ws
+
+# For ROS 2 Rolling
 vcs import --input https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/main/ros2_gz.repos --recursive src
+
+# For ROS 2 Jazzy
+vcs import --input https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/jazzy/ros2_gz.repos --recursive src
+
+# For ROS 2 Humble
+vcs import --input https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/humble/ros2_gz.repos --recursive src
 ```
 
 #### 3. Set the Gazebo version to Harmonic or Garden:
@@ -189,3 +201,8 @@ export SDF_PATH=$GZ_SIM_RESOURCE_PATH
 
 This is assigned in the `iris.launch.py` file as `SDF_PATH` is not usually set
 by the `ament` environment hooks.
+
+## Contributing
+
+`ardupilot_gz` uses the `main` branch for `rolling` development.
+PR's must be targeted to that branch and can be backported to the stable branches.


### PR DESCRIPTION
# Purpose

We're going to move ardupilot_gz to treat `main` as rolling, then have stable `humble` and `jazzy` branches.
Between the branches, we expect minimal changes, and will plan to maintain both of those, so I added mergify rules (pulled from grid_map, removed `iron`): https://github.com/ANYbotics/grid_map/blob/rolling/.github/.mergify.yml

We should enable mergify before this goes in. 