### PR TITLE
feat: Multiagent functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ This simulation includes a skid-steer rover equipped with a 2d lidar in a plaype
 ros2 launch ardupilot_gz_bringup wildthumper_playpen.launch.py rviz:=true use_gz_tf:=true
 ```
 
+### 3. Multi-vehicle simulation
+
+This simulation includes the three currently available models (iris camera, iris lidar, and wild thumper) but can be expanded to an abitrary amount of robots by changing the `robots` list in the launch file.
+
+```bash
+ros2 launch ardupilot_gz_bringup multiagent.launch.py rviz:=true use_gz_tf:=true
+```
 
 ## Notes
 

--- a/ardupilot_gz_bringup/config/iris_2Dlidar_bridge.yaml
+++ b/ardupilot_gz_bringup/config/iris_2Dlidar_bridge.yaml
@@ -5,34 +5,34 @@
   gz_type_name: "gz.msgs.Clock"
   direction: GZ_TO_ROS
 - ros_topic_name: "joint_states"
-  gz_topic_name: "/world/map/model/iris/joint_state"
+  gz_topic_name: "/world/map/model/<robot_name>/joint_state"
   ros_type_name: "sensor_msgs/msg/JointState"
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
 - ros_topic_name: "odometry"
-  gz_topic_name: "/model/iris/odometry"
+  gz_topic_name: "/model/<robot_name>/odometry"
   ros_type_name: "nav_msgs/msg/Odometry"
   gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
 - ros_topic_name: "gz/tf"
-  gz_topic_name: "/model/iris/pose"
+  gz_topic_name: "/model/<robot_name>/pose"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
 - ros_topic_name: "gz/tf_static"
-  gz_topic_name: "/model/iris/pose_static"
+  gz_topic_name: "/model/<robot_name>/pose_static"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "imu"
-  gz_topic_name: "/world/map/model/iris/link/imu_link/sensor/imu_sensor/imu"
+  gz_topic_name: "/world/map/model/<robot_name>/link/imu_link/sensor/imu_sensor/imu"
   ros_type_name: "sensor_msgs/msg/Imu"
   gz_type_name: "gz.msgs.IMU"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "battery"
-  gz_topic_name: "/model/iris/battery/linear_battery/state"
+  gz_topic_name: "/model/<robot_name>/battery/linear_battery/state"
   ros_type_name: "sensor_msgs/msg/BatteryState"
   gz_type_name: "gz.msgs.BatteryState"
   direction: GZ_TO_ROS

--- a/ardupilot_gz_bringup/config/iris_3Dlidar_bridge.yaml
+++ b/ardupilot_gz_bringup/config/iris_3Dlidar_bridge.yaml
@@ -5,34 +5,34 @@
   gz_type_name: "gz.msgs.Clock"
   direction: GZ_TO_ROS
 - ros_topic_name: "joint_states"
-  gz_topic_name: "/world/map/model/iris/joint_state"
+  gz_topic_name: "/world/map/model/<robot_name>/joint_state"
   ros_type_name: "sensor_msgs/msg/JointState"
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
 - ros_topic_name: "odometry"
-  gz_topic_name: "/model/iris/odometry"
+  gz_topic_name: "/model/<robot_name>/odometry"
   ros_type_name: "nav_msgs/msg/Odometry"
   gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
 - ros_topic_name: "gz/tf"
-  gz_topic_name: "/model/iris/pose"
+  gz_topic_name: "/model/<robot_name>/pose"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
 - ros_topic_name: "gz/tf_static"
-  gz_topic_name: "/model/iris/pose_static"
+  gz_topic_name: "/model/<robot_name>/pose_static"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "imu"
-  gz_topic_name: "/world/map/model/iris/link/imu_link/sensor/imu_sensor/imu"
+  gz_topic_name: "/world/map/model/<robot_name>/link/imu_link/sensor/imu_sensor/imu"
   ros_type_name: "sensor_msgs/msg/Imu"
   gz_type_name: "gz.msgs.IMU"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "battery"
-  gz_topic_name: "/model/iris/battery/linear_battery/state"
+  gz_topic_name: "/model/<robot_name>/battery/linear_battery/state"
   ros_type_name: "sensor_msgs/msg/BatteryState"
   gz_type_name: "gz.msgs.BatteryState"
   direction: GZ_TO_ROS

--- a/ardupilot_gz_bringup/config/iris_bridge.yaml
+++ b/ardupilot_gz_bringup/config/iris_bridge.yaml
@@ -5,75 +5,75 @@
   gz_type_name: "gz.msgs.Clock"
   direction: GZ_TO_ROS
 - ros_topic_name: "joint_states"
-  gz_topic_name: "/world/map/model/iris/joint_state"
+  gz_topic_name: "/world/map/model/<robot_name>/joint_state"
   ros_type_name: "sensor_msgs/msg/JointState"
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
 - ros_topic_name: "odometry"
-  gz_topic_name: "/model/iris/odometry"
+  gz_topic_name: "/model/<robot_name>/odometry"
   ros_type_name: "nav_msgs/msg/Odometry"
   gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
 - ros_topic_name: "gz/tf"
-  gz_topic_name: "/model/iris/pose"
+  gz_topic_name: "/model/<robot_name>/pose"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
 - ros_topic_name: "gz/tf_static"
-  gz_topic_name: "/model/iris/pose_static"
+  gz_topic_name: "/model/<robot_name>/pose_static"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "camera/image"
-  gz_topic_name: "/world/map/model/iris/link/pitch_link/sensor/camera/image"
+  gz_topic_name: "/world/map/model/<robot_name>/link/pitch_link/sensor/camera/image"
   ros_type_name: "sensor_msgs/msg/Image"
   gz_type_name: "gz.msgs.Image"
   direction: GZ_TO_ROS
 - ros_topic_name: "camera/camera_info"
-  gz_topic_name: "/world/map/model/iris/link/pitch_link/sensor/camera/camera_info"
+  gz_topic_name: "/world/map/model/<robot_name>/link/pitch_link/sensor/camera/camera_info"
   ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "gz.msgs.CameraInfo"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "air_pressure"
-  gz_topic_name: "/world/map/model/iris/link/base_link/sensor/air_pressure_sensor/air_pressure"
+  gz_topic_name: "/world/map/model/<robot_name>/link/base_link/sensor/air_pressure_sensor/air_pressure"
   ros_type_name: "sensor_msgs/msg/FluidPressure"
   gz_type_name: "gz.msgs.FluidPressure"
   direction: GZ_TO_ROS
 
 # - ros_topic_name: "air_speed"
-#   gz_topic_name: "/world/map/model/iris/link/base_link/sensor/air_speed_sensor/air_speed"
+#   gz_topic_name: "/world/map/model/<robot_name>/link/base_link/sensor/air_speed_sensor/air_speed"
 #   ros_type_name: "geometry_msgs/msg/Vector3Stamped"
 #   gz_type_name: "gz.msgs.AirSpeedSensor"
 #   direction: GZ_TO_ROS
 
 # - ros_topic_name: "altimeter"
-#   gz_topic_name: "/world/map/model/iris/link/base_link/sensor/altimeter_sensor/altimeter"
+#   gz_topic_name: "/world/map/model/<robot_name>/link/base_link/sensor/altimeter_sensor/altimeter"
 #   ros_type_name: "geometry_msgs/msg/Vector3Stamped"
 #   gz_type_name: "gz.msgs.Altimeter"
 #   direction: GZ_TO_ROS
 
 - ros_topic_name: "imu"
-  gz_topic_name: "/world/map/model/iris/link/imu_link/sensor/imu_sensor/imu"
+  gz_topic_name: "/world/map/model/<robot_name>/link/imu_link/sensor/imu_sensor/imu"
   ros_type_name: "sensor_msgs/msg/Imu"
   gz_type_name: "gz.msgs.IMU"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "magnetometer"
-  gz_topic_name: "/world/map/model/iris/link/base_link/sensor/magnetometer_sensor/magnetometer"
+  gz_topic_name: "/world/map/model/<robot_name>/link/base_link/sensor/magnetometer_sensor/magnetometer"
   ros_type_name: "sensor_msgs/msg/MagneticField"
   gz_type_name: "gz.msgs.Magnetometer"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "navsat"
-  gz_topic_name: "/world/map/model/iris/link/base_link/sensor/navsat_sensor/navsat"
+  gz_topic_name: "/world/map/model/<robot_name>/link/base_link/sensor/navsat_sensor/navsat"
   ros_type_name: "sensor_msgs/msg/NavSatFix"
   gz_type_name: "gz.msgs.NavSat"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "battery"
-  gz_topic_name: "/model/iris/battery/linear_battery/state"
+  gz_topic_name: "/model/<robot_name>/battery/linear_battery/state"
   ros_type_name: "sensor_msgs/msg/BatteryState"
   gz_type_name: "gz.msgs.BatteryState"
   direction: GZ_TO_ROS

--- a/ardupilot_gz_bringup/config/wildthumper_bridge.yaml
+++ b/ardupilot_gz_bringup/config/wildthumper_bridge.yaml
@@ -5,46 +5,46 @@
   gz_type_name: "gz.msgs.Clock"
   direction: GZ_TO_ROS
 - ros_topic_name: "joint_states"
-  gz_topic_name: "/world/playpen/model/wildthumper/joint_state"
+  gz_topic_name: "/world/map/model/<robot_name>/joint_state"
   ros_type_name: "sensor_msgs/msg/JointState"
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
 - ros_topic_name: "odometry"
-  gz_topic_name: "/model/wildthumper/odometry"
+  gz_topic_name: "/model/<robot_name>/odometry"
   ros_type_name: "nav_msgs/msg/Odometry"
   gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
 - ros_topic_name: "gz/tf"
-  gz_topic_name: "/model/wildthumper/pose"
+  gz_topic_name: "/model/<robot_name>/pose"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
 - ros_topic_name: "gz/tf_static"
-  gz_topic_name: "/model/wildthumper/pose_static"
+  gz_topic_name: "/model/<robot_name>/pose_static"
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "imu"
-  gz_topic_name: "/world/playpen/model/wildthumper/link/imu_link/sensor/imu_sensor/imu"
+  gz_topic_name: "/world/map/model/<robot_name>/link/imu_link/sensor/imu_sensor/imu"
   ros_type_name: "sensor_msgs/msg/Imu"
   gz_type_name: "gz.msgs.IMU"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "magnetometer"
-  gz_topic_name: "/world/playpen/model/wildthumper/link/base_link/sensor/magnetometer_sensor/magnetometer"
+  gz_topic_name: "/world/map/model/<robot_name>/link/base_link/sensor/magnetometer_sensor/magnetometer"
   ros_type_name: "sensor_msgs/msg/MagneticField"
   gz_type_name: "gz.msgs.Magnetometer"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "navsat"
-  gz_topic_name: "/world/playpen/model/wildthumper/link/base_link/sensor/navsat_sensor/navsat"
+  gz_topic_name: "/world/map/model/<robot_name>/link/base_link/sensor/navsat_sensor/navsat"
   ros_type_name: "sensor_msgs/msg/NavSatFix"
   gz_type_name: "gz.msgs.NavSat"
   direction: GZ_TO_ROS
 
 - ros_topic_name: "battery"
-  gz_topic_name: "/model/wildthumper/battery/linear_battery/state"
+  gz_topic_name: "/model/<robot_name>/battery/linear_battery/state"
   ros_type_name: "sensor_msgs/msg/BatteryState"
   gz_type_name: "gz.msgs.BatteryState"
   direction: GZ_TO_ROS

--- a/ardupilot_gz_bringup/launch/iris_maze.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_maze.launch.py
@@ -88,6 +88,7 @@ def generate_launch_description():
             f'{Path(pkg_ros_gz_sim) / "launch" / "gz_sim.launch.py"}'
         ),
         launch_arguments={"gz_args": "-v4 -g"}.items(),
+        condition=IfCondition(LaunchConfiguration("gui")),
     )
 
     # RViz.
@@ -110,6 +111,9 @@ def generate_launch_description():
         [
             DeclareLaunchArgument(
                 "rviz", default_value="true", description="Open RViz."
+            ),
+            DeclareLaunchArgument(
+                "gui", default_value="true", description="Run Gazebo simulation headless."
             ),
             gz_sim_server,
             gz_sim_gui,

--- a/ardupilot_gz_bringup/launch/iris_maze.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_maze.launch.py
@@ -33,15 +33,11 @@
 from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PathJoinSubstitution
-
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -67,7 +63,6 @@ def generate_launch_description():
             ]
         ),
         launch_arguments={
-            "model": "iris_with_lidar",
             "name": "iris",
             "x": "0",
             "y": "0",
@@ -99,11 +94,16 @@ def generate_launch_description():
     rviz = Node(
         package="rviz2",
         executable="rviz2",
+        namespace="iris",
         arguments=[
             "-d",
             f'{Path(pkg_project_bringup) / "rviz" / "iris_with_lidar.rviz"}',
         ],
         condition=IfCondition(LaunchConfiguration("rviz")),
+        remappings=[
+            ("/tf", "tf"),
+            ("/tf_static", "tf_static"),
+        ]
     )
 
     return LaunchDescription(

--- a/ardupilot_gz_bringup/launch/iris_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_runway.launch.py
@@ -33,15 +33,11 @@
 from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PathJoinSubstitution
-
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -65,7 +61,17 @@ def generate_launch_description():
                     ]
                 ),
             ]
-        )
+        ),
+        launch_arguments={
+            "model": "iris_with_gimbal",
+            "name": "iris",
+            "x": "0",
+            "y": "0",
+            "z": "0.195",
+            "R": "0.0",
+            "P": "0.0",
+            "Y": "1.5708"
+        }.items(),
     )
 
     # Gazebo.

--- a/ardupilot_gz_bringup/launch/iris_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_runway.launch.py
@@ -96,8 +96,13 @@ def generate_launch_description():
     rviz = Node(
         package="rviz2",
         executable="rviz2",
+        namespace="iris",
         arguments=["-d", f'{Path(pkg_project_bringup) / "rviz" / "iris.rviz"}'],
         condition=IfCondition(LaunchConfiguration("rviz")),
+        remappings=[
+            ("/tf", "tf"),
+            ("/tf_static", "tf_static"),
+        ]
     )
 
     return LaunchDescription(

--- a/ardupilot_gz_bringup/launch/iris_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_runway.launch.py
@@ -63,7 +63,6 @@ def generate_launch_description():
             ]
         ),
         launch_arguments={
-            "model": "iris_with_gimbal",
             "name": "iris",
             "x": "0.0",
             "y": "0.0",

--- a/ardupilot_gz_bringup/launch/iris_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_runway.launch.py
@@ -65,8 +65,8 @@ def generate_launch_description():
         launch_arguments={
             "model": "iris_with_gimbal",
             "name": "iris",
-            "x": "0",
-            "y": "0",
+            "x": "0.0",
+            "y": "0.0",
             "z": "0.195",
             "R": "0.0",
             "P": "0.0",

--- a/ardupilot_gz_bringup/launch/iris_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_runway.launch.py
@@ -89,6 +89,7 @@ def generate_launch_description():
             f'{Path(pkg_ros_gz_sim) / "launch" / "gz_sim.launch.py"}'
         ),
         launch_arguments={"gz_args": "-v4 -g"}.items(),
+        condition=IfCondition(LaunchConfiguration("gui")),
     )
 
     # RViz.
@@ -108,6 +109,9 @@ def generate_launch_description():
         [
             DeclareLaunchArgument(
                 "rviz", default_value="true", description="Open RViz."
+            ),
+            DeclareLaunchArgument(
+                "gui", default_value="true", description="Run Gazebo simulation headless."
             ),
             gz_sim_server,
             gz_sim_gui,

--- a/ardupilot_gz_bringup/launch/multiagent.launch.py
+++ b/ardupilot_gz_bringup/launch/multiagent.launch.py
@@ -1,0 +1,114 @@
+# Copyright 2025 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Launch multiple vehicles in Gazebo and Rviz."""
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    """Generate a launch description for a iris quadcopter."""
+    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
+    pkg_project_gazebo = get_package_share_directory("ardupilot_gz_gazebo")
+    pkg_ros_gz_sim = get_package_share_directory("ros_gz_sim")
+    
+    robots = [
+        {'name': 'drone1', "model": "iris_with_gimbal", 'position': ['0.0', '0.0', '0.195', '0', '0', '1.5708']}, # [x, y, z, roll, pitch, yaw]
+        {'name': 'drone2', "model": "iris_with_gimbal", 'position': ['0.0', '1.0', '0.195', '0', '0', '1.5708']}
+    ]
+
+    launch_actions = [
+        DeclareLaunchArgument(
+            "rviz", default_value="true", description="Open RViz."
+        ),
+        DeclareLaunchArgument(
+            "gui", default_value="true", description="Run Gazebo simulation headless."
+        ),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                f'{Path(pkg_ros_gz_sim) / "launch" / "gz_sim.launch.py"}'
+            ),
+            launch_arguments={
+                "gz_args": "-v4 -s -r "
+                f'{Path(pkg_project_gazebo) / "worlds" / "iris_runway.sdf"}'
+            }.items(),
+        ),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                f'{Path(pkg_ros_gz_sim) / "launch" / "gz_sim.launch.py"}'
+            ),
+            launch_arguments={"gz_args": "-v4 -g"}.items(),
+            condition=IfCondition(LaunchConfiguration("gui")),
+        )
+    ]
+
+    for i, robot in enumerate(robots):
+        instance = i
+        sysid = i + 1
+
+        name = robot['name']
+        model = robot['model']
+        position = robot['position']
+
+        drone = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [
+                    PathJoinSubstitution(
+                        [
+                            FindPackageShare("ardupilot_gz_bringup"),
+                            "launch",
+                            "robots",
+                            "iris.launch.py",
+                        ]
+                    ),
+                ]
+            ),
+            launch_arguments={
+                "model": model,
+                "name": name,
+                "x": position[0],
+                "y": position[1],
+                "z": position[2],
+                "R": position[3],
+                "P": position[4],
+                "Y": position[5],
+                "instance": str(instance),
+                "sysid": str(sysid),
+            }.items(),
+        )
+        launch_actions.append(drone)
+
+        rviz = Node(
+            package="rviz2",
+            executable="rviz2",
+            namespace=name,
+            arguments=["-d", f'{Path(pkg_project_bringup) / "rviz" / "iris.rviz"}'],
+            condition=IfCondition(LaunchConfiguration("rviz")),
+            remappings=[
+                ("/tf", "tf"),
+                ("/tf_static", "tf_static"),
+            ]
+        )
+        launch_actions.append(rviz)
+
+    return LaunchDescription(launch_actions)

--- a/ardupilot_gz_bringup/launch/robots/iris.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris.launch.py
@@ -36,30 +36,183 @@ sitl:=127.0.0.1:5501
 import os
 
 from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
-from launch.actions import RegisterEventHandler
-
+from launch.actions import (DeclareLaunchArgument, IncludeLaunchDescription,
+                            OpaqueFunction, RegisterEventHandler)
 from launch.conditions import IfCondition
-
 from launch.event_handlers import OnProcessStart
-
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PathJoinSubstitution
-
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
+def launch_spawn_robot(context):
+    """Return a Gazebo spawn robot launch description"""
+    # Get substitutions for arguments
+    name = LaunchConfiguration("name")
+    pos_x = LaunchConfiguration("x")
+    pos_y = LaunchConfiguration("y")
+    pos_z = LaunchConfiguration("z")
+    rot_r = LaunchConfiguration("R")
+    rot_p = LaunchConfiguration("P")
+    rot_y = LaunchConfiguration("Y")
+
+    # spawn robot
+    spawn_robot =  Node(
+        package="ros_gz_sim",
+        executable="create",
+        namespace=name,
+        arguments=[
+            "-world",
+            "",
+            "-param",
+            "",
+            "-name",
+            name,
+            "-topic",
+            "/robot_description",
+            "-x",
+            pos_x,
+            "-y",
+            pos_y,
+            "-z",
+            pos_z,
+            "-R",
+            rot_r,
+            "-P",
+            rot_p,
+            "-Y",
+            rot_y,
+        ],
+        output="screen",
+    )
+    return [spawn_robot]
+
+
+def launch_state_pub_with_bridge(context):
+    model_name = LaunchConfiguration("model").perform(context)
+    pkg_ardupilot_gazebo = get_package_share_directory("ardupilot_gazebo")
+    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
+
+    # Load SDF file.
+    sdf_file = os.path.join(
+        pkg_ardupilot_gazebo, "models", model_name, "model.sdf"
+    )
+    with open(sdf_file, "r") as infp:
+        robot_desc = infp.read()
+
+    # Publish /tf and /tf_static.
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="both",
+        parameters=[
+            {"robot_description": robot_desc},
+            {"frame_prefix": ""},
+        ],
+    )
+
+    # Bridge.
+    bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        parameters=[
+            {
+                "config_file": os.path.join(
+                    pkg_project_bringup, "config", "iris_bridge.yaml"
+                ),
+                "qos_overrides./tf_static.publisher.durability": "transient_local",
+            }
+        ],
+        output="screen",
+    )
+
+    # Relay - use instead of transform when Gazebo is only publishing odom -> base_link
+    topic_tools_tf = Node(
+        package="topic_tools",
+        executable="relay",
+        arguments=[
+            "/gz/tf",
+            "/tf",
+        ],
+        output="screen",
+        respawn=False,
+        condition=IfCondition(LaunchConfiguration("use_gz_tf")),
+    )
+    
+    event = RegisterEventHandler(
+        OnProcessStart(
+            target_action=bridge,
+            on_start=[
+                topic_tools_tf
+            ]
+        )
+    )
+    
+    return [robot_state_publisher, bridge, event]
+
+
+def generate_launch_arguments():
+    """Generate a list of launch arguments"""
+    return [
+        DeclareLaunchArgument(
+            "use_gz_tf", 
+            default_value="true", 
+            description="Use Gazebo TF."
+        ),
+        # Gazebo model launch arguments.
+        DeclareLaunchArgument(
+            "model",
+            default_value="iris_with_gimbal",
+            description="Name or filepath of the model to load.",
+        ),
+        DeclareLaunchArgument(
+            "name",
+            default_value="iris",
+            description="Name for the model instance.",
+        ),
+        DeclareLaunchArgument(
+            "x",
+            default_value="0",
+            description="The intial 'x' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "y",
+            default_value="0",
+            description="The intial 'y' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "z",
+            default_value="0",
+            description="The intial 'z' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "R",
+            default_value="0",
+            description="The intial roll angle (radians).",
+        ),
+        DeclareLaunchArgument(
+            "P",
+            default_value="0",
+            description="The intial pitch angle (radians).",
+        ),
+        DeclareLaunchArgument(
+            "Y",
+            default_value="0",
+            description="The intial yaw angle (radians).",
+        ),
+    ]
+
 
 def generate_launch_description():
     """Generate a launch description for a iris quadcopter."""
+    
+    launch_arguments = generate_launch_arguments()
+    
     pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
     pkg_ardupilot_gazebo = get_package_share_directory("ardupilot_gazebo")
-    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
 
     # Include component launch files.
     sitl_dds = IncludeLaunchDescription(
@@ -101,8 +254,6 @@ def generate_launch_description():
         }.items(),
     )
 
-    # Robot description.
-
     # Ensure `SDF_PATH` is populated as `sdformat_urdf`` uses this rather
     # than `GZ_SIM_RESOURCE_PATH` to locate resources.
     if "GZ_SIM_RESOURCE_PATH" in os.environ:
@@ -113,88 +264,12 @@ def generate_launch_description():
             os.environ["SDF_PATH"] = sdf_path + ":" + gz_sim_resource_path
         else:
             os.environ["SDF_PATH"] = gz_sim_resource_path
+    
+    opfunc_robot_state_publisher = OpaqueFunction(function=launch_state_pub_with_bridge)
+    opfunc_spawn_robot = OpaqueFunction(function=launch_spawn_robot)
+    ld = LaunchDescription(launch_arguments)
+    ld.add_action(opfunc_robot_state_publisher)
+    ld.add_action(sitl_dds)
+    ld.add_action(opfunc_spawn_robot)
 
-    # Load SDF file.
-    sdf_file = os.path.join(
-        pkg_ardupilot_gazebo, "models", "iris_with_gimbal", "model.sdf"
-    )
-    with open(sdf_file, "r") as infp:
-        robot_desc = infp.read()
-        # print(robot_desc)
-
-    # Publish /tf and /tf_static.
-    robot_state_publisher = Node(
-        package="robot_state_publisher",
-        executable="robot_state_publisher",
-        name="robot_state_publisher",
-        output="both",
-        parameters=[
-            {"robot_description": robot_desc},
-            {"frame_prefix": ""},
-        ],
-    )
-
-    # Bridge.
-    bridge = Node(
-        package="ros_gz_bridge",
-        executable="parameter_bridge",
-        parameters=[
-            {
-                "config_file": os.path.join(
-                    pkg_project_bringup, "config", "iris_bridge.yaml"
-                ),
-                "qos_overrides./tf_static.publisher.durability": "transient_local",
-            }
-        ],
-        output="screen",
-    )
-
-    # Transform - use if the model includes "gz::sim::systems::PosePublisher"
-    #             and a filter is required.
-    # topic_tools_tf = Node(
-    #     package="topic_tools",
-    #     executable="transform",
-    #     arguments=[
-    #         "/gz/tf",
-    #         "/tf",
-    #         "tf2_msgs/msg/TFMessage",
-    #         "tf2_msgs.msg.TFMessage(transforms=[x for x in m.transforms if x.header.frame_id == 'odom'])",
-    #         "--import",
-    #         "tf2_msgs",
-    #         "geometry_msgs",
-    #     ],
-    #     output="screen",
-    #     respawn=True,
-    # )
-
-    # Relay - use instead of transform when Gazebo is only publishing odom -> base_link
-    topic_tools_tf = Node(
-        package="topic_tools",
-        executable="relay",
-        arguments=[
-            "/gz/tf",
-            "/tf",
-        ],
-        output="screen",
-        respawn=False,
-        condition=IfCondition(LaunchConfiguration("use_gz_tf")),
-    )
-
-    return LaunchDescription(
-        [
-            DeclareLaunchArgument(
-                "use_gz_tf", default_value="true", description="Use Gazebo TF."
-            ),
-            sitl_dds,
-            robot_state_publisher,
-            bridge,
-            RegisterEventHandler(
-                OnProcessStart(
-                    target_action=bridge,
-                    on_start=[
-                        topic_tools_tf
-                    ]
-                )
-            ),
-        ]
-    )
+    return ld

--- a/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
@@ -35,9 +35,10 @@ sitl:=127.0.0.1:5501
 """
 import os
 import tempfile
+from typing import List
 
 from ament_index_python.packages import get_package_share_directory
-from launch import LaunchDescription
+from launch import LaunchContext, LaunchDescription, LaunchDescriptionEntity
 from launch.actions import (DeclareLaunchArgument, IncludeLaunchDescription,
                             LogInfo, OpaqueFunction)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -45,7 +46,7 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 
 
-def choose_lidar(context):
+def choose_lidar(context: LaunchContext) -> List[LaunchDescriptionEntity]:
     # Robot description and ros_gz bridge config chosen based on passed lidar_dimension argument
     lidar_dim = LaunchConfiguration("lidar_dim").perform(context)
     name = LaunchConfiguration("name")
@@ -108,6 +109,7 @@ def choose_lidar(context):
             "sdf_file": sdf_file_modified,
             "sitl_config_file": sitl_config_file,
             "bridge_config_file": bridge_config_file,
+            "command": "arducopter",
             "name": name,
             "x": LaunchConfiguration("x"),
             "y": LaunchConfiguration("y"),
@@ -122,7 +124,7 @@ def choose_lidar(context):
 
     return [log, robot]
 
-def generate_launch_arguments():
+def generate_launch_arguments() -> List[LaunchDescriptionEntity]:
     """Generate a list of launch arguments"""
     return [
         DeclareLaunchArgument(
@@ -134,6 +136,17 @@ def generate_launch_arguments():
             "lidar_dim", 
             default_value="3", 
             description="Whether to use a 2D or 3D lidar"
+        ),
+        DeclareLaunchArgument(
+            "instance",
+            default_value="0",
+            description="Set instance of SITL "
+            "(adds 10*instance to all port numbers).",
+        ),
+        DeclareLaunchArgument(
+            "sysid",
+            default_value="",
+            description="Set SYSID_THISMAV.",
         ),
         # Gazebo model launch arguments.
         DeclareLaunchArgument(
@@ -171,20 +184,9 @@ def generate_launch_arguments():
             default_value="0",
             description="The intial yaw angle (radians).",
         ),
-        DeclareLaunchArgument(
-            "instance",
-            default_value="0",
-            description="Set instance of SITL "
-            "(adds 10*instance to all port numbers).",
-        ),
-        DeclareLaunchArgument(
-            "sysid",
-            default_value="",
-            description="Set SYSID_THISMAV.",
-        ),
     ]
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     """Generate a launch description for a iris quadrotor"""
 
     launch_arguments = generate_launch_arguments()

--- a/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
@@ -34,71 +34,27 @@ master:=tcp:127.0.0.1:5760
 sitl:=127.0.0.1:5501
 """
 import os
+import tempfile
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (DeclareLaunchArgument, IncludeLaunchDescription,
-                            LogInfo, OpaqueFunction, RegisterEventHandler)
-from launch.conditions import IfCondition
-from launch.event_handlers import OnProcessStart
+                            LogInfo, OpaqueFunction)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
-def launch_spawn_robot(context):
-    """Return a Gazebo spawn robot launch description"""
-    # Get substitutions for arguments
-    name = LaunchConfiguration("name")
-    pos_x = LaunchConfiguration("x")
-    pos_y = LaunchConfiguration("y")
-    pos_z = LaunchConfiguration("z")
-    rot_r = LaunchConfiguration("R")
-    rot_p = LaunchConfiguration("P")
-    rot_y = LaunchConfiguration("Y")
-
-    # spawn robot
-    spawn_robot =  Node(
-        package="ros_gz_sim",
-        executable="create",
-        namespace=name,
-        arguments=[
-            "-world",
-            "",
-            "-param",
-            "",
-            "-name",
-            name,
-            "-topic",
-            "/robot_description",
-            "-x",
-            pos_x,
-            "-y",
-            pos_y,
-            "-z",
-            pos_z,
-            "-R",
-            rot_r,
-            "-P",
-            rot_p,
-            "-Y",
-            rot_y,
-        ],
-        output="screen",
-    )
-    return [spawn_robot]
-
-
-def launch_state_pub_with_bridge(context):
+def choose_lidar(context):
     # Robot description and ros_gz bridge config chosen based on passed lidar_dimension argument
     lidar_dim = LaunchConfiguration("lidar_dim").perform(context)
-    model_name = LaunchConfiguration("model").perform(context)
+    name = LaunchConfiguration("name")
     pkg_ardupilot_gz_description = get_package_share_directory("ardupilot_gz_description")
     pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
+    pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
     
     sdf_file = os.path.join(
-        pkg_ardupilot_gz_description, "models", model_name, "model.sdf"
+        pkg_ardupilot_gz_description, "models", "iris_with_lidar", "model.sdf"
     )
 
     with open(sdf_file, "r") as infp:
@@ -119,57 +75,52 @@ def launch_state_pub_with_bridge(context):
         log = LogInfo(msg="ERROR: unknown lidar dimensions! Defaulting to 3d lidar")
         robot_desc = robot_desc.replace("<uri>model://lidar_2d</uri>", "<uri>model://lidar_3d</uri>")
         ros_gz_bridge_config = "iris_3Dlidar_bridge.yaml"
+    
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".yaml")
+    sdf_file_modified = temp_file.name
 
-    # Publish /tf and /tf_static.
-    robot_state_publisher = Node(
-        package="robot_state_publisher",
-        executable="robot_state_publisher",
-        name="robot_state_publisher",
-        output="both",
-        parameters=[
-            {"robot_description": robot_desc},
-            {"frame_prefix": ""},
-        ],
+    with open(sdf_file_modified, 'w') as temp_file:
+        temp_file.write(robot_desc)
+
+    sitl_config_file = os.path.join(
+        pkg_ardupilot_sitl, "config", "default_params", "gazebo-iris.parm",
     )
 
-    # Bridge
-    bridge = Node(
-        package="ros_gz_bridge",
-        executable="parameter_bridge",
-        parameters=[
-            {
-                "config_file": os.path.join(
-                    pkg_project_bringup, "config", ros_gz_bridge_config
+    bridge_config_file = os.path.join(
+        pkg_project_bringup, "config", ros_gz_bridge_config
+    )
+
+    robot = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                PathJoinSubstitution(
+                    [
+                        FindPackageShare("ardupilot_gz_bringup"),
+                        "launch",
+                        "robots",
+                        "robot.launch.py",
+                    ]
                 ),
-                "qos_overrides./tf_static.publisher.durability": "transient_local",
-            }
-        ],
-        output="screen",
-    )
-
-    # Relay - use instead of transform when Gazebo is only publishing odom -> base_link
-    topic_tools_tf = Node(
-        package="topic_tools",
-        executable="relay",
-        arguments=[
-            "/gz/tf",
-            "/tf",
-        ],
-        output="screen",
-        respawn=False,
-        condition=IfCondition(LaunchConfiguration("use_gz_tf")),
-    )
-
-    event = RegisterEventHandler(
-        OnProcessStart(
-            target_action=bridge,
-            on_start=[
-                topic_tools_tf
             ]
-        )
+        ),
+        launch_arguments={
+            "use_gz_tf": LaunchConfiguration("use_gz_tf"),
+            "sdf_file": sdf_file_modified,
+            "sitl_config_file": sitl_config_file,
+            "bridge_config_file": bridge_config_file,
+            "name": name,
+            "x": LaunchConfiguration("x"),
+            "y": LaunchConfiguration("y"),
+            "z": LaunchConfiguration("z"),
+            "R": LaunchConfiguration("R"),
+            "P": LaunchConfiguration("P"),
+            "Y": LaunchConfiguration("Y"),
+            "instance": LaunchConfiguration("instance"),
+            "sysid": LaunchConfiguration("sysid"),
+        }.items(),
     )
 
-    return [log, robot_state_publisher, bridge, event]
+    return [log, robot]
 
 def generate_launch_arguments():
     """Generate a list of launch arguments"""
@@ -185,11 +136,6 @@ def generate_launch_arguments():
             description="Whether to use a 2D or 3D lidar"
         ),
         # Gazebo model launch arguments.
-        DeclareLaunchArgument(
-            "model",
-            default_value="iris_with_lidar",
-            description="Name or filepath of the model to load.",
-        ),
         DeclareLaunchArgument(
             "name",
             default_value="iris",
@@ -225,6 +171,17 @@ def generate_launch_arguments():
             default_value="0",
             description="The intial yaw angle (radians).",
         ),
+        DeclareLaunchArgument(
+            "instance",
+            default_value="0",
+            description="Set instance of SITL "
+            "(adds 10*instance to all port numbers).",
+        ),
+        DeclareLaunchArgument(
+            "sysid",
+            default_value="",
+            description="Set SYSID_THISMAV.",
+        ),
     ]
 
 def generate_launch_description():
@@ -232,65 +189,8 @@ def generate_launch_description():
 
     launch_arguments = generate_launch_arguments()
 
-    pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
-
-    # Include component launch files.
-    sitl_dds = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            [
-                PathJoinSubstitution(
-                    [
-                        FindPackageShare("ardupilot_sitl"),
-                        "launch",
-                        "sitl_dds_udp.launch.py",
-                    ]
-                ),
-            ]
-        ),
-        launch_arguments={
-            "transport": "udp4",
-            "port": "2019",
-            "synthetic_clock": "True",
-            "wipe": "False",
-            "model": "json",
-            "speedup": "1",
-            "slave": "0",
-            "instance": "0",
-            "defaults": os.path.join(
-                pkg_ardupilot_sitl,
-                "config",
-                "default_params",
-                "gazebo-iris.parm",
-            )
-            + ","
-            + os.path.join(
-                pkg_ardupilot_sitl,
-                "config",
-                "default_params",
-                "dds_udp.parm",
-            ),
-            "sim_address": "127.0.0.1",
-            "master": "tcp:127.0.0.1:5760",
-            "sitl": "127.0.0.1:5501",
-        }.items(),
+    return LaunchDescription(
+        launch_arguments + [
+            OpaqueFunction(function=choose_lidar)
+        ]
     )
-
-    # Ensure `SDF_PATH` is populated as `sdformat_urdf`` uses this rather
-    # than `GZ_SIM_RESOURCE_PATH` to locate resources.
-    if "GZ_SIM_RESOURCE_PATH" in os.environ:
-        gz_sim_resource_path = os.environ["GZ_SIM_RESOURCE_PATH"]
-
-        if "SDF_PATH" in os.environ:
-            sdf_path = os.environ["SDF_PATH"]
-            os.environ["SDF_PATH"] = sdf_path + ":" + gz_sim_resource_path
-        else:
-            os.environ["SDF_PATH"] = gz_sim_resource_path
-
-    opfunc_robot_state_publisher = OpaqueFunction(function=launch_state_pub_with_bridge)
-    opfunc_spawn_robot = OpaqueFunction(function=launch_spawn_robot)
-    ld = LaunchDescription(launch_arguments)
-    ld.add_action(opfunc_robot_state_publisher)
-    ld.add_action(sitl_dds)
-    ld.add_action(opfunc_spawn_robot)
-
-    return ld

--- a/ardupilot_gz_bringup/launch/robots/robot.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/robot.launch.py
@@ -1,0 +1,360 @@
+# Copyright 2023 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Launch an iris quadcopter in Gazebo and Rviz.
+
+ros2 launch ardupilot_sitl sitl_dds_udp.launch.py
+transport:=udp4
+port:=2019
+synthetic_clock:=True
+wipe:=False
+model:=json
+speedup:=1
+slave:=0
+instance:=0
+defaults:=$(ros2 pkg prefix ardupilot_sitl)
+          /share/ardupilot_sitl/config/default_params/gazebo-iris.parm,
+          $(ros2 pkg prefix ardupilot_sitl)
+          /share/ardupilot_sitl/config/default_params/dds_udp.parm
+sim_address:=127.0.0.1
+master:=tcp:127.0.0.1:5760
+sitl:=127.0.0.1:5501
+"""
+import os
+import tempfile
+from typing import List
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchContext, LaunchDescription, LaunchDescriptionEntity
+from launch.actions import (DeclareLaunchArgument, IncludeLaunchDescription,
+                            OpaqueFunction, RegisterEventHandler)
+from launch.conditions import IfCondition
+from launch.event_handlers import OnProcessStart
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def replace_robot_name(input_file, robot_name):
+    with open(input_file, 'r') as file:
+        content = file.read()
+
+    replaced_content = content.replace("<robot_name>", robot_name)
+
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".yaml")
+    temp_file_name = temp_file.name
+
+    with open(temp_file_name, 'w') as temp_file:
+        temp_file.write(replaced_content)
+
+    return temp_file_name
+
+
+def launch_spawn_robot(context: LaunchContext) -> List[LaunchDescriptionEntity]:
+    """Return a Gazebo spawn robot launch description"""
+    # Get substitutions for arguments
+    name = LaunchConfiguration("name")
+    pos_x = LaunchConfiguration("x")
+    pos_y = LaunchConfiguration("y")
+    pos_z = LaunchConfiguration("z")
+    rot_r = LaunchConfiguration("R")
+    rot_p = LaunchConfiguration("P")
+    rot_y = LaunchConfiguration("Y")
+
+    # spawn robot
+    spawn_robot =  Node(
+        package="ros_gz_sim",
+        executable="create",
+        namespace=name,
+        arguments=[
+            "-world",
+            "",
+            "-param",
+            "",
+            "-name",
+            name,
+            "-topic",
+            "robot_description",
+            "-x",
+            pos_x,
+            "-y",
+            pos_y,
+            "-z",
+            pos_z,
+            "-R",
+            rot_r,
+            "-P",
+            rot_p,
+            "-Y",
+            rot_y,
+        ],
+        output="screen",
+    )
+    return [spawn_robot]
+
+
+def launch_state_pub_with_bridge(context: LaunchContext) -> List[LaunchDescriptionEntity]:
+    name = LaunchConfiguration("name").perform(context)
+    sdf_file = LaunchConfiguration("sdf_file").perform(context)
+    bridge_config_file = LaunchConfiguration("bridge_config_file").perform(context)
+    instance = int(LaunchConfiguration("instance").perform(context))
+
+    # Compute ports
+    port_offset = 10 * instance
+    control_port = 9002 + port_offset
+
+    # Load SDF file.
+    with open(sdf_file, "r") as infp:
+        robot_desc = infp.read()
+
+    robot_desc = robot_desc.replace("<name>iris</name>", f"<name>{name}</name>") # Only needed for iris_with_gimbal
+    robot_desc = robot_desc.replace(
+        "<fdm_port_in>9002</fdm_port_in>", f"<fdm_port_in>{control_port}</fdm_port_in>"
+    )
+
+    # Publish /tf and /tf_static.
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        namespace=name,
+        output="both",
+        parameters=[
+            {"robot_description": robot_desc},
+            {"frame_prefix": ""},
+        ],
+        remappings=[
+            ("/tf", "tf"),
+            ("/tf_static", "tf_static"),
+        ]
+    )
+
+    # Bridge.
+    tmp_bridge_file = replace_robot_name(bridge_config_file, name)
+    bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        namespace=name,
+        parameters=[
+            {
+                "config_file": tmp_bridge_file,
+                "qos_overrides./tf_static.publisher.durability": "transient_local",
+            }
+        ],
+        output="screen",
+    )
+
+    # Relay - use instead of transform when Gazebo is only publishing odom -> base_link
+    topic_tools_tf = Node(
+        package="topic_tools",
+        executable="relay",
+        namespace=name,
+        arguments=[
+            "gz/tf",
+            "tf",
+        ],
+        output="screen",
+        respawn=False,
+        condition=IfCondition(LaunchConfiguration("use_gz_tf")),
+    )
+    
+    event = RegisterEventHandler(
+        OnProcessStart(
+            target_action=bridge,
+            on_start=[
+                topic_tools_tf
+            ]
+        )
+    )
+    
+    return [robot_state_publisher, bridge, event]
+
+
+def launch_sitl_dds(context: LaunchContext) -> List[LaunchDescriptionEntity]:
+    pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
+    
+    # Required arguments.
+    name = LaunchConfiguration("name").perform(context)
+    sitl_config_file = LaunchConfiguration("sitl_config_file").perform(context)
+    instance = int(LaunchConfiguration("instance").perform(context))
+
+    # Optional arguments.
+    sysid = LaunchConfiguration("sysid").perform(context)
+    if not sysid:
+        sysid = instance + 1
+    
+    # Ports
+    port_offset = 10 * instance
+    master_port = 5760 + port_offset
+    sitl_port = 5501 + port_offset
+    sim_address = "127.0.0.1"
+    
+    tty0 = f"./dev/ttyROS{instance * 10}"
+    tty1 = f"./dev/ttyROS{instance * 10 + 1}"
+
+    # Include component launch files.
+    sitl_dds = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                PathJoinSubstitution(
+                    [
+                        FindPackageShare("ardupilot_sitl"),
+                        "launch",
+                        "sitl_dds_udp.launch.py",
+                    ]
+                ),
+            ]
+        ),
+        launch_arguments={
+            # virtual_ports
+            "tty0": tty0,
+            "tty1": tty1,
+            # micro_ros_agent
+            "micro_ros_agent_ns": f"{name}",
+            "baudrate": "115200",
+            "device": tty0,
+            # ardupilot_sitl
+            "synthetic_clock": "True",
+            "wipe": "False",
+            "model": "json",
+            "speedup": "1",
+            "slave": "0",
+            "instance": f"{instance}",
+            "sysid": f"{sysid}",
+            "uartC": f"uart:{tty1}",
+            "defaults": sitl_config_file
+            + ","
+            + os.path.join(
+                pkg_ardupilot_sitl,
+                "config",
+                "default_params",
+                "dds_udp.parm",
+            ),
+            "sim_address": sim_address,
+            "master": f"tcp:{sim_address}:{master_port}",
+            "sitl": f"{sim_address}:{sitl_port}",
+        }.items(),
+    )
+    
+    return [sitl_dds]
+
+
+def generate_launch_arguments():
+    """Generate a list of launch arguments"""
+    pkg_ardupilot_gazebo = get_package_share_directory("ardupilot_gazebo")
+    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
+    return [
+        DeclareLaunchArgument(
+            "use_gz_tf", 
+            default_value="true", 
+            description="Use Gazebo TF."
+        ),
+        DeclareLaunchArgument(
+            "sdf_file",
+            default_value=os.path.join(
+                pkg_ardupilot_gazebo, "models", "iris_with_gimbal", "model.sdf"
+            ),
+            description="Path to robot SDF file.",
+        ),
+        DeclareLaunchArgument(
+            "sitl_config_file",
+            default_value=os.path.join(
+                pkg_ardupilot_gazebo,
+                "config",
+                "gazebo-iris-gimbal.parm",
+            ),
+            description="Path to SITL robot config file.",
+        ),
+        DeclareLaunchArgument(
+            "bridge_config_file",
+            default_value=os.path.join(pkg_project_bringup, "config", "iris_bridge.yaml"),
+            description="Path to ROS Gazebo Bridge config file.",
+        ),
+        # Gazebo model launch arguments.
+        DeclareLaunchArgument(
+            "name",
+            default_value="iris",
+            description="Name for the model instance.",
+        ),
+        DeclareLaunchArgument(
+            "x",
+            default_value="0",
+            description="The intial 'x' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "y",
+            default_value="0",
+            description="The intial 'y' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "z",
+            default_value="0",
+            description="The intial 'z' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "R",
+            default_value="0",
+            description="The intial roll angle (radians).",
+        ),
+        DeclareLaunchArgument(
+            "P",
+            default_value="0",
+            description="The intial pitch angle (radians).",
+        ),
+        DeclareLaunchArgument(
+            "Y",
+            default_value="0",
+            description="The intial yaw angle (radians).",
+        ),
+        DeclareLaunchArgument(
+            "instance",
+            default_value="0",
+            description="Set instance of SITL "
+            "(adds 10*instance to all port numbers).",
+        ),
+        DeclareLaunchArgument(
+            "sysid",
+            default_value="",
+            description="Set SYSID_THISMAV.",
+        ),
+    ]
+
+
+def generate_launch_description():
+    """Generate a launch description for a iris quadcopter."""
+    
+    launch_arguments = generate_launch_arguments()
+
+    # Ensure `SDF_PATH` is populated as `sdformat_urdf`` uses this rather
+    # than `GZ_SIM_RESOURCE_PATH` to locate resources.
+    if "GZ_SIM_RESOURCE_PATH" in os.environ:
+        gz_sim_resource_path = os.environ["GZ_SIM_RESOURCE_PATH"]
+
+        if "SDF_PATH" in os.environ:
+            sdf_path = os.environ["SDF_PATH"]
+            os.environ["SDF_PATH"] = sdf_path + ":" + gz_sim_resource_path
+        else:
+            os.environ["SDF_PATH"] = gz_sim_resource_path
+    
+    opfunc_robot_state_publisher = OpaqueFunction(function=launch_state_pub_with_bridge)
+    opfunc_spawn_robot = OpaqueFunction(function=launch_spawn_robot)
+    opfunc_sitl = OpaqueFunction(function=launch_sitl_dds)
+    ld = LaunchDescription(launch_arguments)
+    ld.add_action(opfunc_robot_state_publisher)
+    ld.add_action(opfunc_sitl)
+    ld.add_action(opfunc_spawn_robot)
+
+    return ld

--- a/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
@@ -35,16 +35,17 @@ sitl:=127.0.0.1:5501
 """
 import os
 import tempfile
+from typing import List
 
 from ament_index_python.packages import get_package_share_directory
-from launch import LaunchDescription
+from launch import LaunchDescription, LaunchDescriptionEntity
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 
 
-def generate_launch_arguments():
+def generate_launch_arguments() -> List[LaunchDescriptionEntity]:
     """Generate a list of launch arguments"""
     return [
         DeclareLaunchArgument(
@@ -102,7 +103,7 @@ def generate_launch_arguments():
     ]
 
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     """Generate a launch description for a wild thumper rover."""
     
     launch_arguments = generate_launch_arguments()
@@ -160,6 +161,7 @@ def generate_launch_description():
             "sdf_file": sdf_file_modified,
             "sitl_config_file": sitl_config_file,
             "bridge_config_file": bridge_config_file,
+            "command": "ardurover",
             "name": LaunchConfiguration("name"),
             "x": LaunchConfiguration("x"),
             "y": LaunchConfiguration("y"),

--- a/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
@@ -34,134 +34,15 @@ master:=tcp:127.0.0.1:5760
 sitl:=127.0.0.1:5501
 """
 import os
+import tempfile
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import (DeclareLaunchArgument, IncludeLaunchDescription,
-                            OpaqueFunction, RegisterEventHandler)
-from launch.conditions import IfCondition
-from launch.event_handlers import OnProcessStart
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
-
-def launch_spawn_robot(context):
-    """Return a Gazebo spawn robot launch description"""
-    # Get substitutions for arguments
-    name = LaunchConfiguration("name")
-    pos_x = LaunchConfiguration("x")
-    pos_y = LaunchConfiguration("y")
-    pos_z = LaunchConfiguration("z")
-    rot_r = LaunchConfiguration("R")
-    rot_p = LaunchConfiguration("P")
-    rot_y = LaunchConfiguration("Y")
-
-    # spawn robot
-    spawn_robot =  Node(
-        package="ros_gz_sim",
-        executable="create",
-        namespace=name,
-        arguments=[
-            "-world",
-            "",
-            "-param",
-            "",
-            "-name",
-            name,
-            "-topic",
-            "/robot_description",
-            "-x",
-            pos_x,
-            "-y",
-            pos_y,
-            "-z",
-            pos_z,
-            "-R",
-            rot_r,
-            "-P",
-            rot_p,
-            "-Y",
-            rot_y,
-        ],
-        output="screen",
-    )
-    return [spawn_robot]
-
-
-def launch_state_pub_with_bridge(context):
-    model_name = LaunchConfiguration("model").perform(context)
-    pkg_ardupilot_sitl_models = get_package_share_directory("ardupilot_sitl_models")
-    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
-    
-    # Load SDF file.
-    sdf_file = os.path.join(
-        pkg_ardupilot_sitl_models, "models", model_name, "model.sdf"
-    )
-    with open(sdf_file, "r") as infp:
-        robot_desc = infp.read()
-
-        # substitute `models://` with `package://ardupilot_sitl_models/models/`
-        # for sdformat_urdf plugin used by robot_state_publisher
-        robot_desc = robot_desc.replace(
-            "model://wildthumper",
-            "package://ardupilot_sitl_models/models/wildthumper")
-
-        robot_desc = robot_desc.replace(
-            "model://wildthumper_with_lidar",
-            "package://ardupilot_sitl_models/models/wildthumper_with_lidar")
-
-    # Publish /tf and /tf_static.
-    robot_state_publisher = Node(
-        package="robot_state_publisher",
-        executable="robot_state_publisher",
-        name="robot_state_publisher",
-        output="both",
-        parameters=[
-            {"robot_description": robot_desc},
-            {"frame_prefix": ""},
-        ],
-    )
-
-    # Bridge.
-    bridge = Node(
-        package="ros_gz_bridge",
-        executable="parameter_bridge",
-        parameters=[
-            {
-                "config_file": os.path.join(
-                    pkg_project_bringup, "config", "wildthumper_bridge.yaml"
-                ),
-                "qos_overrides./tf_static.publisher.durability": "transient_local",
-            }
-        ],
-        output="screen",
-    )
-
-    # Relay - use instead of transform when Gazebo is only publishing odom -> base_link
-    topic_tools_tf = Node(
-        package="topic_tools",
-        executable="relay",
-        arguments=[
-            "/gz/tf",
-            "/tf",
-        ],
-        output="screen",
-        respawn=False,
-        condition=IfCondition(LaunchConfiguration("use_gz_tf")),
-    )
-    
-    event = RegisterEventHandler(
-        OnProcessStart(
-            target_action=bridge,
-            on_start=[
-                topic_tools_tf
-            ]
-        )
-    )
-    
-    return [robot_state_publisher, bridge, event]
 
 def generate_launch_arguments():
     """Generate a list of launch arguments"""
@@ -172,11 +53,6 @@ def generate_launch_arguments():
             description="Use Gazebo TF."
         ),
         # Gazebo model launch arguments.
-        DeclareLaunchArgument(
-            "model",
-            default_value="wildthumper_with_lidar",
-            description="Name or filepath of the model to load.",
-        ),
         DeclareLaunchArgument(
             "name",
             default_value="wildthumper",
@@ -212,6 +88,17 @@ def generate_launch_arguments():
             default_value="0",
             description="The intial yaw angle (radians).",
         ),
+        DeclareLaunchArgument(
+            "instance",
+            default_value="0",
+            description="Set instance of SITL "
+            "(adds 10*instance to all port numbers).",
+        ),
+        DeclareLaunchArgument(
+            "sysid",
+            default_value="",
+            description="Set SYSID_THISMAV.",
+        ),
     ]
 
 
@@ -220,66 +107,73 @@ def generate_launch_description():
     
     launch_arguments = generate_launch_arguments()
     
+    pkg_ardupilot_sitl_models = get_package_share_directory("ardupilot_sitl_models")
+    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
     pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
+    
+    # Load SDF file.
+    sdf_file = os.path.join(
+        pkg_ardupilot_sitl_models, "models", "wildthumper_with_lidar", "model.sdf"
+    )
+    with open(sdf_file, "r") as infp:
+        robot_desc = infp.read()
 
-    # Include component launch files.
-    sitl_dds = IncludeLaunchDescription(
+        # substitute `models://` with `package://ardupilot_sitl_models/models/`
+        # for sdformat_urdf plugin used by robot_state_publisher
+        robot_desc = robot_desc.replace(
+            "model://wildthumper",
+            "package://ardupilot_sitl_models/models/wildthumper")
+
+        robot_desc = robot_desc.replace(
+            "model://wildthumper_with_lidar",
+            "package://ardupilot_sitl_models/models/wildthumper_with_lidar")
+
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".yaml")
+    sdf_file_modified = temp_file.name
+
+    with open(sdf_file_modified, 'w') as temp_file:
+        temp_file.write(robot_desc)
+    
+    sitl_config_file = os.path.join(
+        pkg_ardupilot_sitl, "config", "default_params", "rover-skid.parm"
+    )
+
+    bridge_config_file = os.path.join(
+        pkg_project_bringup, "config", "wildthumper_bridge.yaml"
+    )
+    
+    robot = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
                 PathJoinSubstitution(
                     [
-                        FindPackageShare("ardupilot_sitl"),
+                        FindPackageShare("ardupilot_gz_bringup"),
                         "launch",
-                        "sitl_dds_udp.launch.py",
+                        "robots",
+                        "robot.launch.py",
                     ]
                 ),
             ]
         ),
         launch_arguments={
-            "transport": "udp4",
-            "port": "2019",
-            "command": "ardurover",
-            "synthetic_clock": "True",
-            "wipe": "False",
-            "model": "json",
-            "speedup": "1",
-            "slave": "0",
-            "instance": "0",
-            "defaults": os.path.join(
-                pkg_ardupilot_sitl,
-                "config",
-                "default_params",
-                "rover-skid.parm",
-            )
-            + ","
-            + os.path.join(
-                pkg_ardupilot_sitl,
-                "config",
-                "default_params",
-                "dds_udp.parm",
-            ),
-            "sim_address": "127.0.0.1",
-            "master": "tcp:127.0.0.1:5760",
-            "sitl": "127.0.0.1:5501",
+            "use_gz_tf": LaunchConfiguration("use_gz_tf"),
+            "sdf_file": sdf_file_modified,
+            "sitl_config_file": sitl_config_file,
+            "bridge_config_file": bridge_config_file,
+            "name": LaunchConfiguration("name"),
+            "x": LaunchConfiguration("x"),
+            "y": LaunchConfiguration("y"),
+            "z": LaunchConfiguration("z"),
+            "R": LaunchConfiguration("R"),
+            "P": LaunchConfiguration("P"),
+            "Y": LaunchConfiguration("Y"),
+            "instance": LaunchConfiguration("instance"),
+            "sysid": LaunchConfiguration("sysid"),
         }.items(),
     )
 
-    # Ensure `SDF_PATH` is populated as `sdformat_urdf`` uses this rather
-    # than `GZ_SIM_RESOURCE_PATH` to locate resources.
-    if "GZ_SIM_RESOURCE_PATH" in os.environ:
-        gz_sim_resource_path = os.environ["GZ_SIM_RESOURCE_PATH"]
-
-        if "SDF_PATH" in os.environ:
-            sdf_path = os.environ["SDF_PATH"]
-            os.environ["SDF_PATH"] = sdf_path + ":" + gz_sim_resource_path
-        else:
-            os.environ["SDF_PATH"] = gz_sim_resource_path
-
-    opfunc_robot_state_publisher = OpaqueFunction(function=launch_state_pub_with_bridge)
-    opfunc_spawn_robot = OpaqueFunction(function=launch_spawn_robot)
-    ld = LaunchDescription(launch_arguments)
-    ld.add_action(opfunc_robot_state_publisher)
-    ld.add_action(sitl_dds)
-    ld.add_action(opfunc_spawn_robot)
-
-    return ld
+    return LaunchDescription(
+        launch_arguments + [
+            robot,
+        ]
+    )

--- a/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
+++ b/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
@@ -98,6 +98,10 @@ def generate_launch_description():
         executable="rviz2",
         arguments=["-d", f'{Path(pkg_project_bringup) / "rviz" / "wildthumper.rviz"}'],
         condition=IfCondition(LaunchConfiguration("rviz")),
+        remappings=[
+            ("/tf", "tf"),
+            ("/tf_static", "tf_static"),
+        ]
     )
 
     return LaunchDescription(

--- a/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
+++ b/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
@@ -33,15 +33,11 @@
 from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PathJoinSubstitution
-
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -65,7 +61,17 @@ def generate_launch_description():
                     ]
                 ),
             ]
-        )
+        ),
+        launch_arguments={
+            "model": "wildthumper_with_lidar",
+            "name": "wildthumper",
+            "x": "0.0",
+            "y": "0.0",
+            "z": "0.15",
+            "R": "0.0",
+            "P": "0.0",
+            "Y": "0.0"
+        }.items(),
     )
 
     # Gazebo.

--- a/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
+++ b/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
@@ -89,6 +89,7 @@ def generate_launch_description():
             f'{Path(pkg_ros_gz_sim) / "launch" / "gz_sim.launch.py"}'
         ),
         launch_arguments={"gz_args": "-v4 -g"}.items(),
+        condition=IfCondition(LaunchConfiguration("gui")),
     )
 
     # RViz.
@@ -108,6 +109,9 @@ def generate_launch_description():
         [
             DeclareLaunchArgument(
                 "rviz", default_value="true", description="Open RViz."
+            ),
+            DeclareLaunchArgument(
+                "gui", default_value="true", description="Run Gazebo simulation headless."
             ),
             gz_sim_server,
             gz_sim_gui,

--- a/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
+++ b/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
@@ -63,7 +63,6 @@ def generate_launch_description():
             ]
         ),
         launch_arguments={
-            "model": "wildthumper_with_lidar",
             "name": "wildthumper",
             "x": "0.0",
             "y": "0.0",
@@ -95,6 +94,7 @@ def generate_launch_description():
     # RViz.
     rviz = Node(
         package="rviz2",
+        namespace="wildthumper",
         executable="rviz2",
         arguments=["-d", f'{Path(pkg_project_bringup) / "rviz" / "wildthumper.rviz"}'],
         condition=IfCondition(LaunchConfiguration("rviz")),

--- a/ardupilot_gz_bringup/rviz/iris.rviz
+++ b/ardupilot_gz_bringup/rviz/iris.rviz
@@ -66,7 +66,7 @@ Visualization Manager:
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /robot_description
+            Value: robot_description
           Enabled: true
           Links:
             All Links Enabled: true
@@ -213,7 +213,7 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /odometry
+            Value: odometry
           Value: true
         - Class: rviz_default_plugins/Image
           Enabled: true
@@ -227,7 +227,7 @@ Visualization Manager:
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /camera/image
+            Value: camera/image
           Value: true
       Enabled: true
       Name: Iris

--- a/ardupilot_gz_bringup/rviz/iris_with_lidar.rviz
+++ b/ardupilot_gz_bringup/rviz/iris_with_lidar.rviz
@@ -67,7 +67,7 @@ Visualization Manager:
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /robot_description
+            Value: robot_description
           Enabled: true
           Links:
             All Links Enabled: true
@@ -197,7 +197,7 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /odometry
+            Value: odometry
           Value: true
         - Alpha: 1
           Autocompute Intensity Bounds: true
@@ -229,7 +229,7 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /scan
+            Value: scan
           Use Fixed Frame: true
           Use rainbow: true
           Value: true
@@ -265,7 +265,7 @@ Visualization Manager:
         Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /cloud_in
+        Value: cloud_in
       Use Fixed Frame: true
       Use rainbow: true
       Value: true

--- a/ardupilot_gz_bringup/rviz/wildthumper.rviz
+++ b/ardupilot_gz_bringup/rviz/wildthumper.rviz
@@ -67,7 +67,7 @@ Visualization Manager:
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /robot_description
+            Value: robot_description
           Enabled: true
           Links:
             All Links Enabled: true
@@ -314,7 +314,7 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /odometry
+            Value: odometry
           Value: true
         - Alpha: 1
           Autocompute Intensity Bounds: true
@@ -346,7 +346,7 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /scan
+            Value: scan
           Use Fixed Frame: true
           Use rainbow: true
           Value: true

--- a/ardupilot_gz_gazebo/worlds/iris_runway.sdf
+++ b/ardupilot_gz_gazebo/worlds/iris_runway.sdf
@@ -72,11 +72,5 @@
         <pose degrees="true">-29 545 0 0 0 363</pose>
     </include>
 
-    <include>
-      <uri>model://iris_with_gimbal</uri>
-      <name>iris</name>
-      <pose degrees="true">0 0 0.195 0 0 90</pose>
-    </include>
-
   </world>
 </sdf>

--- a/ardupilot_gz_gazebo/worlds/wildthumper_playpen.sdf
+++ b/ardupilot_gz_gazebo/worlds/wildthumper_playpen.sdf
@@ -62,12 +62,5 @@
       <pose degrees="true">0 0 0 0 0 0</pose>
       <uri>model://rover_playpen</uri>
     </include>
-
-    <include>
-      <pose degrees="true">0 0 0.15 0 0 0</pose>
-      <uri>model://wildthumper_with_lidar</uri>
-      <name>wildthumper</name>
-    </include>
-
   </world>
 </sdf>

--- a/ardupilot_gz_gazebo/worlds/wildthumper_playpen.sdf
+++ b/ardupilot_gz_gazebo/worlds/wildthumper_playpen.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.9">
-  <world name="playpen">
+  <world name="map">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1.0</real_time_factor>


### PR DESCRIPTION
This PR adds multiagent functionality to the Ardupilot simulation. 

Previous discussions:
- https://github.com/ArduPilot/ardupilot_gazebo/issues/89
- https://discuss.ardupilot.org/t/multi-vehicle-zephyr-and-iris-ardupilot-gazebo-simulation-going-to-different-points-in-gazebo-simulation-for-the-same-lat-lon-alt/90686/4
- https://github.com/ArduPilot/ardupilot_gz/issues/65

This work builds on #64 extending the spawning via launch file functionality from just the Lidar example to all models available in this repository. The multiagent part is an extension of https://github.com/srmainwaring/ardupilot_gz/tree/prs/pr-multi-vehicle that takes into account the proper namespace handling for all nodes including RVIZ where the config was switched to use relativ paths and the `ros_gz_bridge` where the robot name is dynamically swapped out.

Example usage:
```
ros2 launch ardupilot_gz_bringup multiagent.launch.py
```

![multiagent_ardupilot](https://github.com/user-attachments/assets/8a6dee1c-0904-4237-a6d4-1b50128f39fd)

Further changes:
- Extracted common code from `iris_lidar.launch.py`, `iris.launch.py` and `wildthumper.launch.py` into `robot.launch.py` to decrease duplicated code
- Added `gui` launch argument to make it possible to not start Gazebo GUI