### PR TITLE
Add /ap namespace on /tf and /tf_static topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ $ ros2 topic list
 /parameter_events
 /robot_description
 /rosout
-/tf
-/tf_static
+/ap/tf
+/ap/tf_static
 ```
 
 ## Advanced variations

--- a/ardupilot_gz_bringup/launch/iris_maze.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_maze.launch.py
@@ -104,6 +104,10 @@ def generate_launch_description():
             f'{Path(pkg_project_bringup) / "rviz" / "iris_with_lidar.rviz"}',
         ],
         condition=IfCondition(LaunchConfiguration("rviz")),
+        remappings=[
+            ("/tf", "/ap/tf"),
+            ("/tf_static", "/ap/tf_static"),
+        ],
     )
 
     return LaunchDescription(

--- a/ardupilot_gz_bringup/launch/iris_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_runway.launch.py
@@ -92,6 +92,10 @@ def generate_launch_description():
         executable="rviz2",
         arguments=["-d", f'{Path(pkg_project_bringup) / "rviz" / "iris.rviz"}'],
         condition=IfCondition(LaunchConfiguration("rviz")),
+        remappings=[
+            ("/tf", "/ap/tf"),
+            ("/tf_static", "/ap/tf_static"),
+        ],
     )
 
     return LaunchDescription(

--- a/ardupilot_gz_bringup/launch/robots/iris.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris.launch.py
@@ -54,7 +54,6 @@ from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
-
 def generate_launch_description():
     """Generate a launch description for a iris quadcopter."""
     pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
@@ -122,7 +121,7 @@ def generate_launch_description():
         robot_desc = infp.read()
         # print(robot_desc)
 
-    # Publish /tf and /tf_static.
+    # Publish /ap/tf and /ap/tf_static.
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -131,6 +130,10 @@ def generate_launch_description():
         parameters=[
             {"robot_description": robot_desc},
             {"frame_prefix": ""},
+        ],
+        remappings=[
+            ("/tf", "/ap/tf"),
+            ("/tf_static", "/ap/tf_static"),
         ],
     )
 
@@ -156,7 +159,7 @@ def generate_launch_description():
     #     executable="transform",
     #     arguments=[
     #         "/gz/tf",
-    #         "/tf",
+    #         "/ap/tf",
     #         "tf2_msgs/msg/TFMessage",
     #         "tf2_msgs.msg.TFMessage(transforms=[x for x in m.transforms if x.header.frame_id == 'odom'])",
     #         "--import",
@@ -173,7 +176,7 @@ def generate_launch_description():
         executable="relay",
         arguments=[
             "/gz/tf",
-            "/tf",
+            "/ap/tf",
         ],
         output="screen",
         respawn=False,
@@ -189,12 +192,7 @@ def generate_launch_description():
             robot_state_publisher,
             bridge,
             RegisterEventHandler(
-                OnProcessStart(
-                    target_action=bridge,
-                    on_start=[
-                        topic_tools_tf
-                    ]
-                )
+                OnProcessStart(target_action=bridge, on_start=[topic_tools_tf])
             ),
         ]
     )

--- a/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
@@ -54,7 +54,6 @@ from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
-
 def generate_launch_description():
     """Generate a launch description for a wild thumper rover."""
     pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
@@ -126,14 +125,15 @@ def generate_launch_description():
         # substitute `models://` with `package://ardupilot_sitl_models/models/`
         # for sdformat_urdf plugin used by robot_state_publisher
         robot_desc = robot_desc.replace(
-            "model://wildthumper",
-            "package://ardupilot_sitl_models/models/wildthumper")
+            "model://wildthumper", "package://ardupilot_sitl_models/models/wildthumper"
+        )
 
         robot_desc = robot_desc.replace(
             "model://wildthumper_with_lidar",
-            "package://ardupilot_sitl_models/models/wildthumper_with_lidar")
+            "package://ardupilot_sitl_models/models/wildthumper_with_lidar",
+        )
 
-    # Publish /tf and /tf_static.
+    # Publish /ap/tf and /ap/tf_static.
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -142,6 +142,10 @@ def generate_launch_description():
         parameters=[
             {"robot_description": robot_desc},
             {"frame_prefix": ""},
+        ],
+        remappings=[
+            ("/tf", "/ap/tf"),
+            ("/tf_static", "/ap/tf_static"),
         ],
     )
 
@@ -166,7 +170,7 @@ def generate_launch_description():
         executable="relay",
         arguments=[
             "/gz/tf",
-            "/tf",
+            "/ap/tf",
         ],
         output="screen",
         respawn=False,
@@ -182,12 +186,7 @@ def generate_launch_description():
             robot_state_publisher,
             bridge,
             RegisterEventHandler(
-                OnProcessStart(
-                    target_action=bridge,
-                    on_start=[
-                        topic_tools_tf
-                    ]
-                )
+                OnProcessStart(target_action=bridge, on_start=[topic_tools_tf])
             ),
         ]
     )

--- a/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
+++ b/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
@@ -92,6 +92,10 @@ def generate_launch_description():
         executable="rviz2",
         arguments=["-d", f'{Path(pkg_project_bringup) / "rviz" / "wildthumper.rviz"}'],
         condition=IfCondition(LaunchConfiguration("rviz")),
+        remappings=[
+            ("/tf", "/ap/tf"),
+            ("/tf_static", "/ap/tf_static"),
+        ],
     )
 
     return LaunchDescription(


### PR DESCRIPTION
# Purpose
This PR aims to settle the discussion started on https://github.com/ArduPilot/ardupilot_ros/issues/24#issuecomment-2709322490, by remapping all uses of the `/tf` topic to `/ap/tf` in SITL.

# Dependencies
- [ ] 

These PRs solve ArduPilot/ardupilot_ros#24