### PR TITLE
Gazebo: support Gazebo Ionic

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The project is adapted from the [`ros_gz_project_template`](https://github.com/g
 ## Prerequisites
 
 - Install [ROS 2 Humble](https://docs.ros.org/en/humble/index.html)
-- Install [Gazebo Harmonic (recommended)](https://gazebosim.org/docs/harmonic) or [Gazebo Garden](https://gazebosim.org/docs/garden)
+- Install [Gazebo Harmonic (recommended)](https://gazebosim.org/docs/harmonic) or [Gazebo Ionic](https://gazebosim.org/docs/ionic)
 - Follow the [`Installing Build Dependencies`](https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_DDS#installing-build-dependencies) section of `AP_DDS`'s README
 
 ## Install
@@ -38,7 +38,7 @@ cd ~/ros2_ws
 vcs import --input https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/main/ros2_gz.repos --recursive src
 ```
 
-#### 3. Set the Gazebo version to Harmonic or Garden:
+#### 3. Set the Gazebo version to Harmonic or Ionic
 
 It is recommended to put this in your `~/.bashrc` or equivalent file.
 

--- a/ardupilot_gz_gazebo/CMakeLists.txt
+++ b/ardupilot_gz_gazebo/CMakeLists.txt
@@ -8,23 +8,47 @@ find_package(ament_cmake REQUIRED)
 # --------------------------------------------------------------------------- #
 # Find gz-sim and dependencies.
 
-find_package(gz-cmake3 REQUIRED)
-set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
-
-find_package(gz-plugin2 REQUIRED COMPONENTS register)
-set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
-
-find_package(gz-common5 REQUIRED COMPONENTS profiler)
-set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
-
 # Garden
 if("$ENV{GZ_VERSION}" STREQUAL "garden")
+  find_package(gz-cmake3 REQUIRED)
+  set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
+
+  gz_find_package(gz-plugin2 REQUIRED COMPONENTS register)
+  set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
+
+  gz_find_package(gz-common5 REQUIRED COMPONENTS profiler)
+  set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
+  
   gz_find_package(gz-sim7 REQUIRED)
   set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
 
   message(STATUS "Compiling against Gazebo Garden")
+# Ionic
+elseif("$ENV{GZ_VERSION}" STREQUAL "ionic")
+  find_package(gz-cmake4 REQUIRED)
+  set(GZ_CMAKE_VER ${gz-cmake4_VERSION_MAJOR})
+
+  gz_find_package(gz-plugin3 REQUIRED COMPONENTS register)
+  set(GZ_PLUGIN_VER ${gz-plugin3_VERSION_MAJOR})
+
+  gz_find_package(gz-common6 REQUIRED COMPONENTS profiler)
+  set(GZ_COMMON_VER ${gz-common6_VERSION_MAJOR})
+
+  gz_find_package(gz-sim9 REQUIRED)
+  set(GZ_SIM_VER ${gz-sim9_VERSION_MAJOR})
+
+  message(STATUS "Compiling against Gazebo Ionic")
 # Harmonic (default)
 elseif("$ENV{GZ_VERSION}" STREQUAL "harmonic" OR NOT DEFINED "ENV{GZ_VERSION}")
+  find_package(gz-cmake3 REQUIRED)
+  set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
+
+  gz_find_package(gz-plugin2 REQUIRED COMPONENTS register)
+  set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
+
+  gz_find_package(gz-common5 REQUIRED COMPONENTS profiler)
+  set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
+
   gz_find_package(gz-sim8 REQUIRED)
   set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
 

--- a/ardupilot_gz_gazebo/package.xml
+++ b/ardupilot_gz_gazebo/package.xml
@@ -13,9 +13,23 @@
   <depend>gz-plugin2</depend>
 
   <!-- Garden -->
+  <depend condition="$GZ_VERSION == garden">gz-common5</depend>
+  <depend condition="$GZ_VERSION == garden">gz-cmake3</depend>
+  <depend condition="$GZ_VERSION == garden">gz-plugin2</depend>
   <depend condition="$GZ_VERSION == garden">gz-sim7</depend>
+  <!-- Ionic -->
+  <depend condition="$GZ_VERSION == ionic">gz-common6</depend>
+  <depend condition="$GZ_VERSION == ionic">gz-cmake4</depend>
+  <depend condition="$GZ_VERSION == ionic">gz-plugin3</depend>
+  <depend condition="$GZ_VERSION == ionic">gz-sim9</depend>
   <!-- Harmonic (default) -->
+  <depend condition="$GZ_VERSION == ''">gz-common5</depend>
+  <depend condition="$GZ_VERSION == ''">gz-cmake3</depend>
+  <depend condition="$GZ_VERSION == ''">gz-plugin2</depend>
   <depend condition="$GZ_VERSION == ''">gz-sim8</depend>
+  <depend condition="$GZ_VERSION == harmonic">gz-common5</depend>
+  <depend condition="$GZ_VERSION == harmonic">gz-cmake3</depend>
+  <depend condition="$GZ_VERSION == harmonic">gz-plugin2</depend>
   <depend condition="$GZ_VERSION == harmonic">gz-sim8</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Add build option for Gazebo Ionic. The ROS 2 distros are moving to a new approach using `vendored` packages that do not explicitly state the version number, however I have not managed to get this working for macOS 