### PR TITLE
fix GZ_SIM_PLUGIN_PATH capitalization

### DIFF
--- a/ardupilot_gz_gazebo/hooks/ardupilot_gz_gazebo.sh.in
+++ b/ardupilot_gz_gazebo/hooks/ardupilot_gz_gazebo.sh.in
@@ -1,2 +1,2 @@
 ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
-ament_prepend_unique_value GZ_SIM_PLUGIn_PATH "$AMENT_CURRENT_PREFIX/lib/@PROJECT_NAME@"
+ament_prepend_unique_value GZ_SIM_PLUGIN_PATH "$AMENT_CURRENT_PREFIX/lib/@PROJECT_NAME@"


### PR DESCRIPTION
Hi, I was debugging an unrelated issue and stumbled upon this.

<img width="1126" height="816" alt="image" src="https://github.com/user-attachments/assets/a571d118-c247-4e0a-ac5f-2ca374149909" />
