### PR TITLE
Wildthumper Playpen: Lower physics to 500Hz

### DIFF
--- a/ardupilot_gz_gazebo/worlds/wildthumper_playpen.sdf
+++ b/ardupilot_gz_gazebo/worlds/wildthumper_playpen.sdf
@@ -2,7 +2,7 @@
 <sdf version="1.9">
   <world name="playpen">
     <physics name="1ms" type="ignore">
-      <max_step_size>0.001</max_step_size>
+      <max_step_size>0.002</max_step_size>
       <real_time_factor>1.0</real_time_factor>
     </physics>
 


### PR DESCRIPTION
This PR lowers the physics rate for the ``wildthumper_playpen`` world from 1000Hz to 500Hz, in order to increase performance.

No instabilities noted during testing, and got a doubling of performance (20->40% RTF).

Lowering the physics further (to 250Hz) _did_ introduce instabilities, though.