### PR TITLE
Alti-Transition: add launch file for Alti-Transition quadplane

### DIFF
--- a/ardupilot_gz_bringup/config/alti_transition_bridge.yaml
+++ b/ardupilot_gz_bringup/config/alti_transition_bridge.yaml
@@ -1,0 +1,31 @@
+---
+- ros_topic_name: "clock"
+  gz_topic_name: "/clock"
+  ros_type_name: "rosgraph_msgs/msg/Clock"
+  gz_type_name: "gz.msgs.Clock"
+  direction: GZ_TO_ROS
+- ros_topic_name: "joint_states"
+  gz_topic_name: "/world/{{ world_name }}/model/{{ robot_name }}/joint_state"
+  ros_type_name: "sensor_msgs/msg/JointState"
+  gz_type_name: "gz.msgs.Model"
+  direction: GZ_TO_ROS
+- ros_topic_name: "odometry"
+  gz_topic_name: "/model/{{ robot_name }}/odometry"
+  ros_type_name: "nav_msgs/msg/Odometry"
+  gz_type_name: "gz.msgs.Odometry"
+  direction: GZ_TO_ROS
+- ros_topic_name: "gz/tf"
+  gz_topic_name: "/model/{{ robot_name }}/pose"
+  ros_type_name: "tf2_msgs/msg/TFMessage"
+  gz_type_name: "gz.msgs.Pose_V"
+  direction: GZ_TO_ROS
+- ros_topic_name: "gz/tf_static"
+  gz_topic_name: "/model/{{ robot_name }}/pose_static"
+  ros_type_name: "tf2_msgs/msg/TFMessage"
+  gz_type_name: "gz.msgs.Pose_V"
+  direction: GZ_TO_ROS
+- ros_topic_name: "imu"
+  gz_topic_name: "/world/{{ world_name }}/model/{{ robot_name }}/link/imu_link/sensor/imu_sensor/imu"
+  ros_type_name: "sensor_msgs/msg/Imu"
+  gz_type_name: "gz.msgs.IMU"
+  direction: GZ_TO_ROS

--- a/ardupilot_gz_bringup/launch/alti_transition_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/alti_transition_runway.launch.py
@@ -1,0 +1,113 @@
+# Copyright 2026 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Launch an alti transition quadplane in Gazebo and Rviz."""
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    """Generate a launch description for a alti transition quadplane."""
+    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
+    pkg_project_gazebo = get_package_share_directory("ardupilot_gz_gazebo")
+    pkg_ros_gz_sim = get_package_share_directory("ros_gz_sim")
+
+    # Robot.
+    robot = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                PathJoinSubstitution(
+                    [
+                        pkg_project_bringup,
+                        "launch",
+                        "robots",
+                        "alti_transition.launch.py",
+                    ]
+                ),
+            ]
+        ),
+        condition=IfCondition(LaunchConfiguration("spawn_robot")),
+    )
+
+    # Gazebo.
+    gz_sim_server = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            f'{Path(pkg_ros_gz_sim) / "launch" / "gz_sim.launch.py"}'
+        ),
+        launch_arguments={
+            "gz_args": "-v1 -s -r "
+            f'{Path(pkg_project_gazebo) / "worlds" / "runway.sdf"}'
+        }.items(),
+        condition=IfCondition(LaunchConfiguration("use_gz_sim_server")),
+    )
+
+    gz_sim_gui = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            f'{Path(pkg_ros_gz_sim) / "launch" / "gz_sim.launch.py"}'
+        ),
+        launch_arguments={"gz_args": "-v1 -g"}.items(),
+        condition=IfCondition(LaunchConfiguration("use_gz_sim_gui")),
+    )
+
+    # RViz.
+    rviz = Node(
+        package="rviz2",
+        executable="rviz2",
+        namespace="alti_transition",
+        arguments=["-d", f'{Path(pkg_project_bringup) / "rviz" / "alti_transition.rviz"}'],
+        condition=IfCondition(LaunchConfiguration("rviz")),
+        remappings=[
+            ("/tf", "tf"),
+            ("/tf_static", "tf_static"),
+        ],
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "use_gz_sim_server",
+                default_value="true",
+                description="Run the Gazebo server.",
+            ),
+            DeclareLaunchArgument(
+                "use_gz_sim_gui",
+                default_value="true",
+                description="Run the Gazebo GUI.",
+            ),
+            DeclareLaunchArgument(
+                "spawn_robot",
+                default_value="true",
+                description="Spawn the robot and start SITL+ROS.",
+            ),
+            DeclareLaunchArgument(
+                "rviz", default_value="true", description="Open RViz."
+            ),
+            gz_sim_server,
+            gz_sim_gui,
+            robot,
+            rviz,
+        ]
+    )

--- a/ardupilot_gz_bringup/launch/multiagent.launch.py
+++ b/ardupilot_gz_bringup/launch/multiagent.launch.py
@@ -37,6 +37,7 @@ class Vehicle(Enum):
     IRIS = "iris_with_gimbal"
     IRIS_LIDAR = "iris_lidar"
     WILD_THUMPER = "wildthumper"
+    ALTI_TRANSITION = "alti_transition"
 
 
 VEHICLE_PATHS = {
@@ -51,6 +52,10 @@ VEHICLE_PATHS = {
     Vehicle.WILD_THUMPER: {
         "launch": "wildthumper.launch.py",
         "rviz": "wildthumper.rviz",
+    },
+    Vehicle.ALTI_TRANSITION: {
+        "launch": "alti_transition.launch.py",
+        "rviz": "alti_transition.rviz",
     },
 }
 
@@ -90,6 +95,11 @@ def generate_launch_description():
             "name": "rover1",
             "model": Vehicle.WILD_THUMPER,
             "position": ["-1.0", "0.0", "0.195", "0", "0", "1.5708"],
+        },
+        {
+            "name": "plane1",
+            "model": Vehicle.ALTI_TRANSITION,
+            "position": ["-4.0", "0.0", "0.195", "0", "0", "1.5708"],
         },
     ]
 

--- a/ardupilot_gz_bringup/launch/robots/alti_transition.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/alti_transition.launch.py
@@ -1,0 +1,248 @@
+# Copyright 2026 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Launch an alti-transition quadplane in Gazebo and Rviz.
+"""
+from typing import List
+
+import math
+import os
+import tempfile
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchContext
+from launch import LaunchDescription
+
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.actions import OpaqueFunction
+
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+
+
+def generate_robot_launch_actions(context: LaunchContext, *args, **kwargs):
+    """Launch the robot_state_publisher and ros_gz bridge nodes."""
+    pkg_ardupilot_sitl_models = get_package_share_directory("ardupilot_sitl_models")
+    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
+
+    # Load SDF file.
+    sdf_file = os.path.join(
+        pkg_ardupilot_sitl_models, "models", "alti_transition_quad", "model.sdf"
+    )
+    with open(sdf_file, "r") as infp:
+        robot_desc = infp.read()
+
+    # Substitute `models://` with `package://ardupilot_sitl_models/models/`
+    # for sdformat_urdf plugin used by robot_state_publisher
+    robot_desc = robot_desc.replace(
+        "model://alti_transition_quad",
+        "package://ardupilot_sitl_models/models/alti_transition_quad",
+    )
+
+    robot_desc = robot_desc.replace(
+        "capsule>",
+        "cylinder>",
+    )
+
+    # Ensure the ArduPilot plugin and SITL have a consistent sim_address
+    sim_address = LaunchConfiguration("sim_address").perform(context)
+    robot_desc = robot_desc.replace(
+        "<fdm_addr>127.0.0.1</fdm_addr>",
+        f"<fdm_addr>{sim_address}</fdm_addr>",
+    )
+
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".yaml")
+    sdf_file_modified = temp_file.name
+
+    with open(sdf_file_modified, "w") as temp_file:
+        temp_file.write(robot_desc)
+
+    bridge_config_file = os.path.join(
+        pkg_project_bringup, "config", "alti_transition_bridge.yaml"
+    )
+
+    robot = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                PathJoinSubstitution(
+                    [
+                        pkg_project_bringup,
+                        "launch",
+                        "robots",
+                        "robot.launch.py",
+                    ]
+                ),
+            ]
+        ),
+        launch_arguments={
+            "use_gz_tf": LaunchConfiguration("use_gz_tf"),
+            "sdf_file": sdf_file_modified,
+            "bridge_config_file": bridge_config_file,
+            "command": "arduplane",
+            "robot_name": LaunchConfiguration("robot_name"),
+            "world_name": LaunchConfiguration("world_name"),
+            "model": LaunchConfiguration("model"),
+            "defaults": LaunchConfiguration("defaults"),
+            "synthetic_clock": LaunchConfiguration("synthetic_clock"),
+            "sim_address": LaunchConfiguration("sim_address"),
+            "x": LaunchConfiguration("x"),
+            "y": LaunchConfiguration("y"),
+            "z": LaunchConfiguration("z"),
+            "R": LaunchConfiguration("R"),
+            "P": LaunchConfiguration("P"),
+            "Y": LaunchConfiguration("Y"),
+            "instance": LaunchConfiguration("instance"),
+            "sysid": LaunchConfiguration("sysid"),
+            "use_instance_dir": LaunchConfiguration("use_instance_dir"),
+            "use_dds_agent": LaunchConfiguration("use_dds_agent"),
+        }.items(),
+    )
+
+    return [robot]
+
+
+def generate_launch_arguments() -> List[DeclareLaunchArgument]:
+    """Generate a list of launch arguments."""
+    pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
+    pkg_ardupilot_sitl_models = get_package_share_directory("ardupilot_sitl_models")
+
+    return [
+        # sitl_dds
+        DeclareLaunchArgument(
+            "model",
+            default_value="json",
+            description="Set simulation model. Set default to 'json' for Gazebo.",
+        ),
+        DeclareLaunchArgument(
+            "defaults",
+            default_value=(
+                os.path.join(
+                    pkg_ardupilot_sitl,
+                    "config",
+                    "default_params",
+                    "quadplane.parm",
+                )
+                + ","
+                + os.path.join(
+                    pkg_ardupilot_sitl_models,
+                    "config",
+                    "alti_transition_quad.param",
+                )
+                + ","
+                + os.path.join(
+                    pkg_ardupilot_sitl,
+                    "config",
+                    "default_params",
+                    "dds_udp.parm",
+                )
+                + ","
+                + os.path.join(
+                    pkg_ardupilot_sitl,
+                    "config",
+                    "default_params",
+                    "dds_use_ns.parm",
+                )
+            ),
+            description="Set path to default params for the robot with DDS.",
+        ),
+        DeclareLaunchArgument(
+            "synthetic_clock",
+            default_value="True",
+        ),
+        DeclareLaunchArgument(
+            "sim_address",
+            default_value="127.0.0.1",
+        ),
+        DeclareLaunchArgument(
+            "instance",
+            default_value="0",
+            description="Set instance of SITL "
+            "(adds 10*instance to all port numbers).",
+        ),
+        DeclareLaunchArgument(
+            "sysid",
+            default_value="",
+            description="Set SYSID_THISMAV.",
+        ),
+        DeclareLaunchArgument(
+            "use_instance_dir",
+            default_value="False",
+            description="If True create instance directories for the eeprom.bin.",
+        ),
+        DeclareLaunchArgument(
+            "use_dds_agent",
+            default_value="True",
+            description="If True launch the micro-ros-agent.",
+        ),
+        # topic_tools_tf
+        DeclareLaunchArgument(
+            "use_gz_tf", default_value="true", description="Use Gazebo TF."
+        ),
+        # bridge, spawn_robot
+        DeclareLaunchArgument(
+            "world_name",
+            default_value="runway",
+            description="Name for the world instance.",
+        ),
+        DeclareLaunchArgument(
+            "robot_name",
+            default_value="alti_transition",
+            description="Name for the model instance.",
+        ),
+        DeclareLaunchArgument(
+            "x",
+            default_value="0.0",
+            description="The initial 'x' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "y",
+            default_value="0.0",
+            description="The initial 'y' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "z",
+            default_value="0.15",
+            description="The initial 'z' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "R",
+            default_value="0.0",
+            description="The initial roll angle (radians).",
+        ),
+        DeclareLaunchArgument(
+            "P",
+            default_value="0.0",
+            description="The initial pitch angle (radians).",
+        ),
+        DeclareLaunchArgument(
+            "Y",
+            default_value=f"{math.radians(90)}",
+            description="The initial yaw angle (radians).",
+        ),
+    ]
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Generate a launch description for the robot"""
+
+    launch_arguments = generate_launch_arguments()
+
+    return LaunchDescription(
+        launch_arguments + [OpaqueFunction(function=generate_robot_launch_actions)]
+    )

--- a/ardupilot_gz_bringup/rviz/alti_transition.rviz
+++ b/ardupilot_gz_bringup/rviz/alti_transition.rviz
@@ -1,0 +1,315 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /AltiTransition1
+      Splitter Ratio: 0.5
+    Tree Height: 587
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Class: rviz_common/Group
+      Displays:
+        - Alpha: 0.5
+          Cell Size: 1
+          Class: rviz_default_plugins/Grid
+          Color: 160; 160; 164
+          Enabled: true
+          Line Style:
+            Line Width: 0.029999999329447746
+            Value: Lines
+          Name: Grid
+          Normal Cell Count: 0
+          Offset:
+            X: 0
+            Y: 0
+            Z: 0
+          Plane: XY
+          Plane Cell Count: 10
+          Reference Frame: <Fixed Frame>
+          Value: true
+        - Class: rviz_default_plugins/Axes
+          Enabled: true
+          Length: 10
+          Name: Axes
+          Radius: 0.05000000074505806
+          Reference Frame: <Fixed Frame>
+          Value: true
+        - Alpha: 1
+          Class: rviz_default_plugins/RobotModel
+          Collision Enabled: false
+          Description File: ""
+          Description Source: Topic
+          Description Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: robot_description
+          Enabled: true
+          Links:
+            All Links Enabled: true
+            Expand Joint Details: false
+            Expand Link Details: false
+            Expand Tree: false
+            Link Tree Style: Links in Alphabetic Order
+            base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            elevator_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            imu_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            left_aileron_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            motor_1:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            motor_2:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            motor_3:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            motor_4:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            motor_f:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            right_aileron_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+          Mass Properties:
+            Inertia: false
+            Mass: false
+          Name: RobotModel
+          TF Prefix: ""
+          Update Interval: 0
+          Value: true
+          Visual Enabled: true
+        - Class: rviz_default_plugins/TF
+          Enabled: true
+          Filter (blacklist): ""
+          Filter (whitelist): ""
+          Frame Timeout: 15
+          Frames:
+            All Enabled: true
+            base_link:
+              Value: true
+            elevator_link:
+              Value: true
+            imu_link:
+              Value: true
+            left_aileron_link:
+              Value: true
+            motor_1:
+              Value: true
+            motor_2:
+              Value: true
+            motor_3:
+              Value: true
+            motor_4:
+              Value: true
+            motor_f:
+              Value: true
+            odom:
+              Value: true
+            right_aileron_link:
+              Value: true
+          Marker Scale: 1
+          Name: TF
+          Show Arrows: true
+          Show Axes: true
+          Show Names: false
+          Tree:
+            odom:
+              base_link:
+                elevator_link:
+                  {}
+                imu_link:
+                  {}
+                left_aileron_link:
+                  {}
+                motor_1:
+                  {}
+                motor_2:
+                  {}
+                motor_3:
+                  {}
+                motor_4:
+                  {}
+                motor_f:
+                  {}
+                right_aileron_link:
+                  {}
+          Update Interval: 0
+          Value: true
+        - Angle Tolerance: 0.10000000149011612
+          Class: rviz_default_plugins/Odometry
+          Covariance:
+            Orientation:
+              Alpha: 0.5
+              Color: 255; 255; 127
+              Color Style: Unique
+              Frame: Local
+              Offset: 1
+              Scale: 1
+              Value: true
+            Position:
+              Alpha: 0.30000001192092896
+              Color: 204; 51; 204
+              Scale: 1
+              Value: true
+            Value: true
+          Enabled: true
+          Keep: 500
+          Name: Odometry
+          Position Tolerance: 0.10000000149011612
+          Shape:
+            Alpha: 1
+            Axes Length: 1
+            Axes Radius: 0.10000000149011612
+            Color: 255; 25; 0
+            Head Length: 0.30000001192092896
+            Head Radius: 0.10000000149011612
+            Shaft Length: 1
+            Shaft Radius: 0.05000000074505806
+            Value: Arrow
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: odometry
+          Value: true
+      Enabled: true
+      Name: AltiTransition
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: odom
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 7.110143661499023
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.780073881149292
+        Y: 1.6334694623947144
+        Z: -0.6402829885482788
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.4297952950000763
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 5.203584671020508
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 800
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001630000029afc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006200fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002c0000029a000000e300fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d006100670065010000019c0000012a0000000000000000000000010000010f0000029bfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002c0000029b000000c600fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b00000023800fffffffb0000000800540069006d006501000000000000045000000000000000000000034c0000029a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1200
+  X: 0
+  Y: 38


### PR DESCRIPTION
Add launch scripts to bring up an Alti-Transition quadplane in Gazebo with ROS/DDS integration.

Depends on:

- https://github.com/ArduPilot/ardupilot/pull/32493
- https://github.com/ArduPilot/ardupilot_gz/pull/67
- https://github.com/ArduPilot/SITL_Models/pull/152
- https://github.com/ArduPilot/SITL_Models/pull/153

### Testing

Bringup vehicle and simulation

```bash
ros2 launch ardupilot_gz_bringup alti_transition_runway.launch.py rviz:=true use_gz_tf:=true rviz:=false
```

Start a mavproxy session

```bash
mavproxy.py --master 127.0.0.1:14550 --console --map
```

Check services

```bash
% ros2 service list
/alti_transition/relay/describe_parameters
/alti_transition/relay/get_parameter_types
/alti_transition/relay/get_parameters
/alti_transition/relay/get_type_description
/alti_transition/relay/list_parameters
/alti_transition/relay/set_parameters
/alti_transition/relay/set_parameters_atomically
/alti_transition/robot_state_publisher/describe_parameters
/alti_transition/robot_state_publisher/get_parameter_types
/alti_transition/robot_state_publisher/get_parameters
/alti_transition/robot_state_publisher/get_type_description
/alti_transition/robot_state_publisher/list_parameters
/alti_transition/robot_state_publisher/set_parameters
/alti_transition/robot_state_publisher/set_parameters_atomically
/alti_transition/ros_gz_bridge/describe_parameters
/alti_transition/ros_gz_bridge/get_parameter_types
/alti_transition/ros_gz_bridge/get_parameters
/alti_transition/ros_gz_bridge/get_type_description
/alti_transition/ros_gz_bridge/list_parameters
/alti_transition/ros_gz_bridge/set_parameters
/alti_transition/ros_gz_bridge/set_parameters_atomically
/ap/arm_motors
/ap/experimental/takeoff
/ap/get_parameters
/ap/mode_switch
/ap/prearm_check
/ap/set_parameters
```

Switch to guided in MAVProxy

```bash
FBWA> mode guided
GUIDED>
```

Use ROS to arm and takeoff 

```bash
% ros2 service call /ap/arm_motors ardupilot_msgs/srv/ArmMotors "{arm: true}" 
requester: making request: ardupilot_msgs.srv.ArmMotors_Request(arm=True)

response:
ardupilot_msgs.srv.ArmMotors_Response(result=True)
```

```bash
% ros2 service call /ap/experimental/takeoff ardupilot_msgs/srv/Takeoff "{alt: 2}"
requester: making request: ardupilot_msgs.srv.Takeoff_Request(alt=2.0)

response:
ardupilot_msgs.srv.Takeoff_Response(status=True)
```

<img width="512" height="331" alt="02-alti-launch-and-takeoff" src="https://github.com/user-attachments/assets/1cd569cd-d709-4040-bee4-1e42aa4aa93b" />
