### PR TITLE
Fix typo discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ ros2 launch ardupilot_gz_bringup iris_warehouse.launch.py rviz:=true use_gz_tf:=
 
 ### 4. Multi-vehicle simulation
 
-This simulation includes the three currently available models (iris camera, iris lidar, and wild thumper) but can be expanded to an abitrary amount of robots by changing the `robots` list in the launch file.
+This simulation includes the three currently available models (iris camera, iris lidar, and wild thumper) but can be expanded to an arbitrary amount of robots by changing the `robots` list in the launch file.
 
 ```bash
 ros2 launch ardupilot_gz_bringup multiagent.launch.py rviz:=true use_gz_tf:=true


### PR DESCRIPTION
Fix typo discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=infp,parm,sitl`
```
./README.md:147: abitrary ==> arbitrary
```
% `codespell --ignore-words-list=infp,parm,sitl --write-changes` 