### PR TITLE
Add namespace as launch parameter

### DIFF
--- a/ardupilot_gz_bringup/launch/alti_transition_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/alti_transition_runway.launch.py
@@ -76,7 +76,7 @@ def generate_launch_description():
     rviz = Node(
         package="rviz2",
         executable="rviz2",
-        namespace="alti_transition",
+        namespace=LaunchConfiguration("namespace"),
         arguments=["-d", f'{Path(pkg_project_bringup) / "rviz" / "alti_transition.rviz"}'],
         condition=IfCondition(LaunchConfiguration("rviz")),
         remappings=[
@@ -87,6 +87,11 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            DeclareLaunchArgument(
+                "namespace",
+                default_value="",
+                description="Robot namespace.",
+            ),
             DeclareLaunchArgument(
                 "use_gz_sim_server",
                 default_value="true",

--- a/ardupilot_gz_bringup/launch/iris_maze.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_maze.launch.py
@@ -88,7 +88,7 @@ def generate_launch_description():
     rviz = Node(
         package="rviz2",
         executable="rviz2",
-        namespace="iris",
+        namespace=LaunchConfiguration("namespace"),
         arguments=[
             "-d",
             f'{Path(pkg_project_bringup) / "rviz" / "iris_with_lidar.rviz"}',
@@ -102,6 +102,11 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            DeclareLaunchArgument(
+                "namespace",
+                default_value="",
+                description="Robot namespace.",
+            ),
             DeclareLaunchArgument(
                 "use_gz_sim_server",
                 default_value="true",

--- a/ardupilot_gz_bringup/launch/iris_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_runway.launch.py
@@ -92,7 +92,7 @@ def generate_launch_description():
     rviz = Node(
         package="rviz2",
         executable="rviz2",
-        namespace="iris",
+        namespace=LaunchConfiguration("namespace"),
         arguments=["-d", f'{Path(pkg_project_bringup) / "rviz" / "iris.rviz"}'],
         condition=IfCondition(LaunchConfiguration("rviz")),
         remappings=[
@@ -103,6 +103,11 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            DeclareLaunchArgument(
+                "namespace",
+                default_value="",
+                description="Robot namespace.",
+            ),
             DeclareLaunchArgument(
                 "use_gz_sim_server",
                 default_value="true",

--- a/ardupilot_gz_bringup/launch/iris_warehouse.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_warehouse.launch.py
@@ -96,7 +96,7 @@ def generate_launch_description():
     rviz = Node(
         package="rviz2",
         executable="rviz2",
-        namespace="iris",
+        namespace=LaunchConfiguration("namespace"),
         arguments=[
             "-d",
             f'{Path(pkg_project_bringup) / "rviz" / "iris_with_lidar.rviz"}',
@@ -110,6 +110,11 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            DeclareLaunchArgument(
+                "namespace",
+                default_value="",
+                description="Robot namespace.",
+            ),
             DeclareLaunchArgument(
                 "world_name",
                 default_value="warehouse",

--- a/ardupilot_gz_bringup/launch/multiagent.launch.py
+++ b/ardupilot_gz_bringup/launch/multiagent.launch.py
@@ -106,6 +106,11 @@ def generate_launch_description():
     def generate_launch_actions(context: LaunchContext, *args, **kwargs):
         launch_actions = [
             DeclareLaunchArgument(
+                "namespace",
+                default_value="",
+                description="Robot namespace.",
+            ),
+            DeclareLaunchArgument(
                 "rviz", default_value="true", description="Open RViz."
             ),
             DeclareLaunchArgument(
@@ -135,6 +140,7 @@ def generate_launch_description():
             instance = i
             sysid = i + 1
 
+            namespace = robot["name"]
             name = robot["name"]
             model = robot["model"]
             position = robot["position"]
@@ -156,6 +162,7 @@ def generate_launch_description():
             drone_launch_arguments = get_default_launch_arguments(drone_lds, context)
             drone_launch_arguments.update(
                 {
+                    "namespace": namespace,
                     "robot_name": name,
                     "world_name": "runway",
                     "x": position[0],
@@ -183,7 +190,7 @@ def generate_launch_description():
             rviz = Node(
                 package="rviz2",
                 executable="rviz2",
-                namespace=name,
+                namespace=namespace,
                 arguments=[
                     "-d",
                     f'{Path(pkg_project_bringup) / "rviz" / VEHICLE_PATHS[model]["rviz"]}',

--- a/ardupilot_gz_bringup/launch/robots/alti_transition.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/alti_transition.launch.py
@@ -91,6 +91,7 @@ def generate_robot_launch_actions(context: LaunchContext, *args, **kwargs):
             ]
         ),
         launch_arguments={
+            "namespace": LaunchConfiguration("namespace"),
             "use_gz_tf": LaunchConfiguration("use_gz_tf"),
             "sdf_file": sdf_file_modified,
             "bridge_config_file": bridge_config_file,
@@ -123,6 +124,12 @@ def generate_launch_arguments() -> List[DeclareLaunchArgument]:
     pkg_ardupilot_sitl_models = get_package_share_directory("ardupilot_sitl_models")
 
     return [
+        # ros-args
+        DeclareLaunchArgument(
+            "namespace",
+            default_value="",
+            description="Robot namespace.",
+        ),
         # sitl_dds
         DeclareLaunchArgument(
             "model",

--- a/ardupilot_gz_bringup/launch/robots/iris.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris.launch.py
@@ -102,6 +102,7 @@ def generate_robot_launch_actions(context: LaunchContext, *args, **kwargs):
             ]
         ),
         launch_arguments={
+            "namespace": LaunchConfiguration("namespace"),
             "use_gz_tf": LaunchConfiguration("use_gz_tf"),
             "sdf_file": sdf_file_modified,
             "bridge_config_file": bridge_config_file,
@@ -134,6 +135,12 @@ def generate_launch_arguments() -> List[DeclareLaunchArgument]:
     pkg_ardupilot_gazebo = get_package_share_directory("ardupilot_gazebo")
 
     return [
+        # ros-args
+        DeclareLaunchArgument(
+            "namespace",
+            default_value="",
+            description="Robot namespace.",
+        ),
         # sitl_dds
         DeclareLaunchArgument(
             "model",

--- a/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
@@ -120,6 +120,7 @@ def generate_robot_launch_actions(context: LaunchContext, *args, **kwargs):
             ]
         ),
         launch_arguments={
+            "namespace": LaunchConfiguration("namespace"),
             "use_gz_tf": LaunchConfiguration("use_gz_tf"),
             "sdf_file": sdf_file_modified,
             "bridge_config_file": bridge_config_file,
@@ -151,6 +152,12 @@ def generate_launch_arguments() -> List[DeclareLaunchArgument]:
     pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
 
     return [
+        # ros-args
+        DeclareLaunchArgument(
+            "namespace",
+            default_value="",
+            description="Robot namespace.",
+        ),
         # sitl_dds
         DeclareLaunchArgument(
             "model",

--- a/ardupilot_gz_bringup/launch/robots/robot.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/robot.launch.py
@@ -59,6 +59,7 @@ def replace_robot_name(input_file: str, robot_name: str, world_name: str) -> str
 def launch_spawn_robot(context: LaunchContext) -> List[LaunchDescriptionEntity]:
     """Return a Gazebo spawn robot launch description"""
     # Get substitutions for arguments
+    namespace = LaunchConfiguration("namespace")
     name = LaunchConfiguration("robot_name")
     pos_x = LaunchConfiguration("x")
     pos_y = LaunchConfiguration("y")
@@ -71,7 +72,7 @@ def launch_spawn_robot(context: LaunchContext) -> List[LaunchDescriptionEntity]:
     spawn_robot = Node(
         package="ros_gz_sim",
         executable="create",
-        namespace=name,
+        namespace=namespace,
         arguments=[
             "-world",
             "",
@@ -102,6 +103,7 @@ def launch_spawn_robot(context: LaunchContext) -> List[LaunchDescriptionEntity]:
 def launch_state_pub_with_bridge(
     context: LaunchContext,
 ) -> List[LaunchDescriptionEntity]:
+    namespace = LaunchConfiguration("namespace").perform(context)
     robot_name = LaunchConfiguration("robot_name").perform(context)
     world_name = LaunchConfiguration("world_name").perform(context)
     sdf_file = LaunchConfiguration("sdf_file").perform(context)
@@ -124,7 +126,7 @@ def launch_state_pub_with_bridge(
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
-        namespace=robot_name,
+        namespace=namespace,
         output="both",
         parameters=[
             {"robot_description": robot_desc},
@@ -141,7 +143,7 @@ def launch_state_pub_with_bridge(
     bridge = Node(
         package="ros_gz_bridge",
         executable="parameter_bridge",
-        namespace=robot_name,
+        namespace=namespace,
         parameters=[
             {
                 "config_file": tmp_bridge_file,
@@ -155,7 +157,7 @@ def launch_state_pub_with_bridge(
     topic_tools_tf = Node(
         package="topic_tools",
         executable="relay",
-        namespace=robot_name,
+        namespace=namespace,
         arguments=[
             "gz/tf",
             "tf",
@@ -262,6 +264,12 @@ def generate_launch_arguments() -> List[LaunchDescriptionEntity]:
     pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
 
     return [
+        # ros-args
+        DeclareLaunchArgument(
+            "namespace",
+            default_value="",
+            description="Robot namespace.",
+        ),
         # sitl_dds
         DeclareLaunchArgument(
             "model",

--- a/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
@@ -106,6 +106,7 @@ def generate_robot_launch_actions(context: LaunchContext, *args, **kwargs):
             ]
         ),
         launch_arguments={
+            "namespace": LaunchConfiguration("namespace"),
             "use_gz_tf": LaunchConfiguration("use_gz_tf"),
             "sdf_file": sdf_file_modified,
             "bridge_config_file": bridge_config_file,
@@ -137,6 +138,12 @@ def generate_launch_arguments() -> List[DeclareLaunchArgument]:
     pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
 
     return [
+        # ros-args
+        DeclareLaunchArgument(
+            "namespace",
+            default_value="",
+            description="Robot namespace.",
+        ),
         # sitl_dds
         DeclareLaunchArgument(
             "model",

--- a/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
+++ b/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
@@ -91,7 +91,7 @@ def generate_launch_description():
     # RViz.
     rviz = Node(
         package="rviz2",
-        namespace="wildthumper",
+        namespace=LaunchConfiguration("namespace"),
         executable="rviz2",
         arguments=["-d", f'{Path(pkg_project_bringup) / "rviz" / "wildthumper.rviz"}'],
         condition=IfCondition(LaunchConfiguration("rviz")),
@@ -103,6 +103,11 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            DeclareLaunchArgument(
+                "namespace",
+                default_value="",
+                description="Robot namespace.",
+            ),
             DeclareLaunchArgument(
                 "use_gz_sim_server",
                 default_value="true",


### PR DESCRIPTION
Add a `namespace` launch argument. This allows the namespace of the ROS 2 nodes to be set independently of the robot name, e.g. using `namespace:="iris"`. The default is to use an empty namespace which provide backwards compatibility with the current cartographer and navigation examples in `ardupilot_ros`. 

### Details

- Make the namespace a separate launch parameter from the robot name.
- Allow named robots to be launched into the global namespace (i.e. __ns:="")
- Added to support compatibility with ardupilot_ros examples.

### Testing

- [x] alti_transition_runway.launch.py with default.
- [x] alti_transition_runway.launch.py with namespace (`namespace:="alti_transition"`).
- [x] iris_maze.launch.py with default.
- [x] iris_maze.launch.py with namespace (`namespace:="iris"`).
- [x] iris_runway.launch.py with default.
- [x] iris_runway.launch.py with  namespace (`namespace:="iris"`).
- [x] iris_warehouse.launch.py with default.
- [x] iris_warehouse.launch.py with namespace (`namespace:="iris"`).
- [x] wildthumper_playpen.launch.py with default.
- [x] wildthumper_playpen.launch.py with  namespace (`namespace:="wildthumper"`).
- [x] multiagent.launch.py with automatic namespace.
