### PR TITLE
feat: Option to configure sensors via XACRO

### DIFF
--- a/ardupilot_gz_bringup/launch/bridge_generator.py
+++ b/ardupilot_gz_bringup/launch/bridge_generator.py
@@ -1,0 +1,341 @@
+# Copyright 2026 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Generate a ros_gz_bridge config (bridge.yaml) from SDF files.
+
+Scans one or more SDF files for ``<sensor>`` elements, determines the
+owning link for each sensor, and emits the corresponding bridge entries
+for the ros_gz parameter bridge.
+
+This lets the same pipeline that xacro-generates sensor SDFs also
+(re)generate a bridge config so the two stay in sync automatically.
+"""
+
+import re
+import xml.etree.ElementTree as ET
+from typing import Dict, List, Tuple
+
+# Base entries that are not tied to a specific sensor (clock, odometry,
+# joint_states, TF, battery). The strings ``{{ world_name }}`` and
+# ``{{ robot_name }}`` are substituted at launch time by
+# ``robot.launch.py`` (``replace_robot_name``).
+_BASE_ENTRIES: List[Dict[str, str]] = [
+    {
+        "ros_topic_name": "clock",
+        "gz_topic_name": "/clock",
+        "ros_type_name": "rosgraph_msgs/msg/Clock",
+        "gz_type_name": "gz.msgs.Clock",
+    },
+    {
+        "ros_topic_name": "joint_states",
+        "gz_topic_name": "/world/{{ world_name }}/model/{{ robot_name }}/joint_state",
+        "ros_type_name": "sensor_msgs/msg/JointState",
+        "gz_type_name": "gz.msgs.Model",
+    },
+    {
+        "ros_topic_name": "odometry",
+        "gz_topic_name": "/model/{{ robot_name }}/odometry",
+        "ros_type_name": "nav_msgs/msg/Odometry",
+        "gz_type_name": "gz.msgs.Odometry",
+    },
+    {
+        "ros_topic_name": "gz/tf",
+        "gz_topic_name": "/model/{{ robot_name }}/pose",
+        "ros_type_name": "tf2_msgs/msg/TFMessage",
+        "gz_type_name": "gz.msgs.Pose_V",
+    },
+    {
+        "ros_topic_name": "gz/tf_static",
+        "gz_topic_name": "/model/{{ robot_name }}/pose_static",
+        "ros_type_name": "tf2_msgs/msg/TFMessage",
+        "gz_type_name": "gz.msgs.Pose_V",
+    },
+    {
+        "ros_topic_name": "battery",
+        "gz_topic_name": "/model/{{ robot_name }}/battery/lipo_3500mAh/state",
+        "ros_type_name": "sensor_msgs/msg/BatteryState",
+        "gz_type_name": "gz.msgs.BatteryState",
+    },
+]
+
+# Maps an SDF sensor ``type`` to the list of outputs we want to bridge.
+# Each output is (gz_suffix, ros_topic_suffix, ros_type, gz_type).
+#
+# gz_suffix: trailing component in the gz topic path,
+#   `/world/<w>/model/<r>/link/<link>/sensor/<sensor>/<gz_suffix>`
+# ros_topic_suffix: ros topic leaf name. For single-output sensors
+#   (imu, magnetometer, ...) this is the bare ros topic name; for
+#   multi-output sensors it is combined with the sensor name as
+#   ``<sensor_name>/<suffix>``.
+_SENSOR_OUTPUTS: Dict[str, List[Tuple[str, str, str, str]]] = {
+    "imu": [
+        ("imu", "imu", "sensor_msgs/msg/Imu", "gz.msgs.IMU"),
+    ],
+    "magnetometer": [
+        (
+            "magnetometer",
+            "magnetometer",
+            "sensor_msgs/msg/MagneticField",
+            "gz.msgs.Magnetometer",
+        ),
+    ],
+    "air_pressure": [
+        (
+            "air_pressure",
+            "air_pressure",
+            "sensor_msgs/msg/FluidPressure",
+            "gz.msgs.FluidPressure",
+        ),
+    ],
+    "altimeter": [
+        (
+            "altimeter",
+            "altimeter",
+            "geometry_msgs/msg/Vector3Stamped",
+            "gz.msgs.Altimeter",
+        ),
+    ],
+    "air_speed": [
+        (
+            "air_speed",
+            "air_speed",
+            "geometry_msgs/msg/Vector3Stamped",
+            "gz.msgs.AirSpeedSensor",
+        ),
+    ],
+    "navsat": [
+        (
+            "navsat",
+            "navsat",
+            "sensor_msgs/msg/NavSatFix",
+            "gz.msgs.NavSat",
+        ),
+        (
+            "navsat",
+            "gpsfix",
+            "gps_msgs/msg/GPSFix",
+            "gz.msgs.NavSat",
+        ),
+    ],
+    "camera": [
+        ("image", "image", "sensor_msgs/msg/Image", "gz.msgs.Image"),
+        (
+            "camera_info",
+            "camera_info",
+            "sensor_msgs/msg/CameraInfo",
+            "gz.msgs.CameraInfo",
+        ),
+    ],
+    "depth_camera": [
+        ("image", "image", "sensor_msgs/msg/Image", "gz.msgs.Image"),
+        (
+            "depth_image",
+            "depth_image",
+            "sensor_msgs/msg/Image",
+            "gz.msgs.Image",
+        ),
+        (
+            "camera_info",
+            "camera_info",
+            "sensor_msgs/msg/CameraInfo",
+            "gz.msgs.CameraInfo",
+        ),
+        (
+            "points",
+            "points",
+            "sensor_msgs/msg/PointCloud2",
+            "gz.msgs.PointCloudPacked",
+        ),
+    ],
+    "rgbd_camera": [
+        ("image", "image", "sensor_msgs/msg/Image", "gz.msgs.Image"),
+        (
+            "depth_image",
+            "depth_image",
+            "sensor_msgs/msg/Image",
+            "gz.msgs.Image",
+        ),
+        (
+            "camera_info",
+            "camera_info",
+            "sensor_msgs/msg/CameraInfo",
+            "gz.msgs.CameraInfo",
+        ),
+        (
+            "points",
+            "points",
+            "sensor_msgs/msg/PointCloud2",
+            "gz.msgs.PointCloudPacked",
+        ),
+    ],
+    "gpu_lidar": [
+        ("scan", "scan", "sensor_msgs/msg/LaserScan", "gz.msgs.LaserScan"),
+        (
+            "scan/points",
+            "scan/points",
+            "sensor_msgs/msg/PointCloud2",
+            "gz.msgs.PointCloudPacked",
+        ),
+    ],
+    "lidar": [
+        ("scan", "scan", "sensor_msgs/msg/LaserScan", "gz.msgs.LaserScan"),
+        (
+            "scan/points",
+            "scan/points",
+            "sensor_msgs/msg/PointCloud2",
+            "gz.msgs.PointCloudPacked",
+        ),
+    ],
+}
+
+# Sensor types whose single output becomes an un-namespaced ros topic
+# (e.g. ``imu`` rather than ``imu_sensor/imu``).
+_BARE_TOPIC_TYPES = {
+    "imu",
+    "magnetometer",
+    "air_pressure",
+    "altimeter",
+    "air_speed",
+    "navsat",
+}
+
+
+def _strip_ns(tag: str) -> str:
+    """Strip XML namespace from a tag name."""
+    return tag.split("}", 1)[1] if "}" in tag else tag
+
+
+def parse_sensors(sdf_path: str) -> List[Dict[str, str]]:
+    """Return a list of ``{link, sensor, type}`` dicts for an SDF file."""
+    tree = ET.parse(sdf_path)
+    root = tree.getroot()
+
+    sensors: List[Dict[str, str]] = []
+
+    def walk(node: ET.Element, current_link: str = "") -> None:
+        tag = _strip_ns(node.tag)
+        if tag == "link":
+            current_link = node.get("name", current_link)
+        if tag == "sensor":
+            sensor_name = node.get("name", "")
+            sensor_type = node.get("type", "")
+            if current_link and sensor_name and sensor_type:
+                sensors.append(
+                    {
+                        "link": current_link,
+                        "sensor": sensor_name,
+                        "type": sensor_type,
+                    }
+                )
+            # Sensors don't contain nested sensors we care about.
+            return
+        for child in node:
+            walk(child, current_link)
+
+    walk(root)
+    return sensors
+
+
+def _short_name(sensor_name: str) -> str:
+    """Strip a trailing ``_sensor`` suffix, e.g. ``imu_sensor`` -> ``imu``."""
+    return re.sub(r"_sensor$", "", sensor_name)
+
+
+def build_entries(sensors: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Convert parsed sensors into bridge yaml entries."""
+    entries: List[Dict[str, str]] = list(_BASE_ENTRIES)
+    seen_ros_topics = {e["ros_topic_name"] for e in entries}
+
+    for sensor in sensors:
+        outputs = _SENSOR_OUTPUTS.get(sensor["type"])
+        if not outputs:
+            continue
+
+        link = sensor["link"]
+        sensor_name = sensor["sensor"]
+        gz_base = (
+            "/world/{{ world_name }}/model/{{ robot_name }}"
+            f"/link/{link}/sensor/{sensor_name}"
+        )
+
+        bare = sensor["type"] in _BARE_TOPIC_TYPES
+        short = _short_name(sensor_name)
+
+        for gz_suffix, ros_suffix, ros_type, gz_type in outputs:
+            if bare:
+                # Prefer the stripped sensor name (imu_sensor -> imu) when
+                # it is distinct, otherwise fall back to the ros suffix.
+                ros_topic = short if short and short != sensor_name else ros_suffix
+            else:
+                ros_topic = f"{sensor_name}/{ros_suffix}"
+
+            # Skip exact duplicates so multiple imu sensors don't collide.
+            if ros_topic in seen_ros_topics:
+                continue
+            seen_ros_topics.add(ros_topic)
+
+            entries.append(
+                {
+                    "ros_topic_name": ros_topic,
+                    "gz_topic_name": f"{gz_base}/{gz_suffix}",
+                    "ros_type_name": ros_type,
+                    "gz_type_name": gz_type,
+                }
+            )
+
+    return entries
+
+
+def _dump_yaml(entries: List[Dict[str, str]]) -> str:
+    """Render entries as a ros_gz_bridge compatible yaml document."""
+    lines = [
+        "# This file is auto-generated by bridge_generator.py.",
+        "# Do not edit: changes are overwritten each time the launch runs.",
+        "---",
+    ]
+    for i, entry in enumerate(entries):
+        prefix = "- "
+        for key in (
+            "ros_topic_name",
+            "gz_topic_name",
+            "ros_type_name",
+            "gz_type_name",
+        ):
+            value = entry[key]
+            lines.append(f'{prefix}{key}: "{value}"')
+            prefix = "  "
+        lines.append("  direction: GZ_TO_ROS")
+        if i != len(entries) - 1:
+            lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def generate_bridge_yaml(sdf_files: List[str], output_path: str) -> str:
+    """Parse ``sdf_files``, write a bridge yaml to ``output_path`` and return it."""
+    all_sensors: List[Dict[str, str]] = []
+    seen = set()
+    for sdf in sdf_files:
+        for s in parse_sensors(sdf):
+            key = (s["link"], s["sensor"], s["type"])
+            if key in seen:
+                continue
+            seen.add(key)
+            all_sensors.append(s)
+    entries = build_entries(all_sensors)
+    content = _dump_yaml(entries)
+    with open(output_path, "w") as f:
+        f.write(content)
+    return output_path

--- a/ardupilot_gz_bringup/launch/iris_with_sensors_warehouse.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_with_sensors_warehouse.launch.py
@@ -1,0 +1,194 @@
+# Copyright 2026 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Launch the iris_with_sensors quadcopter in the warehouse world."""
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import List
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchContext
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.actions import OpaqueFunction
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+
+from launch_ros.actions import Node
+
+
+_SENSOR_XACRO_MODELS = ("lidar", "camera", "depth_camera", "rgbd_camera")
+
+
+def _load_module(module_name: str):
+    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
+    module_path = os.path.join(
+        pkg_project_bringup, "launch", f"{module_name}.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _xacro_to_sdf(xacro_path: str) -> str:
+    sdf_path = xacro_path.replace(".xacro", ".sdf")
+    subprocess.run(
+        ["ros2", "run", "xacro", "xacro", "-o", sdf_path, xacro_path],
+        check=True,
+    )
+    return sdf_path
+
+
+def _build_rviz_node(context: LaunchContext):
+    """Regenerate the rviz config from the sensor SDFs and launch rviz2."""
+    del context  # unused; OpaqueFunction passes it by convention.
+    pkg_ardupilot_gazebo = get_package_share_directory("ardupilot_gazebo")
+    pkg_project_description = get_package_share_directory("ardupilot_gz_description")
+
+    sensor_sdfs: List[str] = []
+    for model_name in _SENSOR_XACRO_MODELS:
+        xacro_file = os.path.join(
+            pkg_project_description, "models", model_name, "model.xacro"
+        )
+        sensor_sdfs.append(_xacro_to_sdf(xacro_file))
+
+    base_sdf = os.path.join(
+        pkg_ardupilot_gazebo, "models", "iris_with_standoffs", "model.sdf"
+    )
+
+    # bridge_generator must be importable before rviz_generator imports it.
+    _load_module("bridge_generator")
+    rviz_generator = _load_module("rviz_generator")
+
+    rviz_tmp = tempfile.NamedTemporaryFile(
+        delete=False, suffix="_iris_with_sensors.rviz"
+    )
+    rviz_tmp.close()
+    rviz_generator.generate_rviz_config([base_sdf] + sensor_sdfs, rviz_tmp.name)
+
+    rviz = Node(
+        package="rviz2",
+        executable="rviz2",
+        namespace=LaunchConfiguration("namespace"),
+        arguments=["-d", rviz_tmp.name],
+        condition=IfCondition(LaunchConfiguration("rviz")),
+        remappings=[
+            ("/tf", "tf"),
+            ("/tf_static", "tf_static"),
+        ],
+    )
+    return [rviz]
+
+
+def generate_launch_description():
+    """Generate a launch description for the iris_with_sensors quadcopter."""
+    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
+    pkg_project_gazebo = get_package_share_directory("ardupilot_gz_gazebo")
+    pkg_ros_gz_sim = get_package_share_directory("ros_gz_sim")
+
+    # Iris with xacro-generated sensors.
+    robot = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                PathJoinSubstitution(
+                    [
+                        pkg_project_bringup,
+                        "launch",
+                        "robots",
+                        "iris_with_sensors.launch.py",
+                    ]
+                ),
+            ]
+        ),
+        launch_arguments={
+            "world_name": LaunchConfiguration("world_name"),
+            "robot_name": LaunchConfiguration("robot_name"),
+        }.items(),
+        condition=IfCondition(LaunchConfiguration("spawn_robot")),
+    )
+
+    # Gazebo.
+    gz_sim_server = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            f'{Path(pkg_ros_gz_sim) / "launch" / "gz_sim.launch.py"}'
+        ),
+        launch_arguments={
+            "gz_args": "-v4 -s -r "
+            + f'{Path(pkg_project_gazebo) / "worlds" / "warehouse.sdf"}'
+        }.items(),
+        condition=IfCondition(LaunchConfiguration("use_gz_sim_server")),
+    )
+
+    gz_sim_gui = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            f'{Path(pkg_ros_gz_sim) / "launch" / "gz_sim.launch.py"}'
+        ),
+        launch_arguments={"gz_args": "-v4 -g"}.items(),
+        condition=IfCondition(LaunchConfiguration("use_gz_sim_gui")),
+    )
+
+    rviz = OpaqueFunction(function=_build_rviz_node)
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "namespace",
+                default_value="",
+                description="Robot namespace.",
+            ),
+            DeclareLaunchArgument(
+                "world_name",
+                default_value="warehouse",
+                description="Name for the world instance.",
+            ),
+            DeclareLaunchArgument(
+                "robot_name",
+                default_value="iris",
+                description="Name for the model instance.",
+            ),
+            DeclareLaunchArgument(
+                "use_gz_sim_server",
+                default_value="true",
+                description="Run the Gazebo server.",
+            ),
+            DeclareLaunchArgument(
+                "use_gz_sim_gui",
+                default_value="true",
+                description="Run the Gazebo GUI.",
+            ),
+            DeclareLaunchArgument(
+                "spawn_robot",
+                default_value="true",
+                description="Spawn the robot and start SITL+ROS.",
+            ),
+            DeclareLaunchArgument(
+                "rviz", default_value="true", description="Open RViz."
+            ),
+            gz_sim_server,
+            gz_sim_gui,
+            robot,
+            rviz,
+        ]
+    )

--- a/ardupilot_gz_bringup/launch/robots/iris_with_sensors.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris_with_sensors.launch.py
@@ -1,0 +1,291 @@
+# Copyright 2026 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Launch an iris quadcopter with xacro-generated sensors in Gazebo."""
+from typing import List
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchContext
+from launch import LaunchDescription
+
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.actions import OpaqueFunction
+
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+
+
+_SENSOR_XACRO_MODELS = ("lidar", "camera", "depth_camera", "rgbd_camera")
+
+
+def _load_bridge_generator():
+    """Import bridge_generator.py sitting alongside this launch folder."""
+    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
+    module_path = os.path.join(pkg_project_bringup, "launch", "bridge_generator.py")
+    spec = importlib.util.spec_from_file_location("bridge_generator", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["bridge_generator"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _xacro_to_sdf(xacro_path: str) -> str:
+    """Run xacro synchronously, writing the SDF next to the xacro source."""
+    sdf_path = xacro_path.replace(".xacro", ".sdf")
+    subprocess.run(
+        ["ros2", "run", "xacro", "xacro", "-o", sdf_path, xacro_path],
+        check=True,
+    )
+    return sdf_path
+
+
+def generate_robot_launch_actions(context: LaunchContext, *args, **kwargs):
+    """Launch robot_state_publisher, bridge, SITL and spawn actions."""
+    pkg_ardupilot_gazebo = get_package_share_directory("ardupilot_gazebo")
+    pkg_project_description = get_package_share_directory("ardupilot_gz_description")
+    pkg_project_bringup = get_package_share_directory("ardupilot_gz_bringup")
+
+    # 1) Run xacro on each sensor model so the sensor SDFs are up to date.
+    #    The generated SDFs are written next to the xacro source so that
+    #    ``model://<name>`` lookups through GZ_SIM_RESOURCE_PATH resolve
+    #    to the freshly generated file.
+    sensor_sdf_paths: List[str] = []
+    for model_name in _SENSOR_XACRO_MODELS:
+        xacro_file = os.path.join(
+            pkg_project_description, "models", model_name, "model.xacro"
+        )
+        sensor_sdf_paths.append(_xacro_to_sdf(xacro_file))
+
+    # 2) Auto-generate the bridge.yaml from the union of sensors found in
+    #    the base iris model plus every generated sensor SDF. This keeps
+    #    the bridge in sync with whatever sensors are currently declared
+    #    in the xacro sources.
+    base_sdf = os.path.join(
+        pkg_ardupilot_gazebo, "models", "iris_with_standoffs", "model.sdf"
+    )
+    bridge_generator = _load_bridge_generator()
+    bridge_tmp = tempfile.NamedTemporaryFile(
+        delete=False, suffix="_iris_with_sensors_bridge.yaml"
+    )
+    bridge_tmp.close()
+    bridge_generator.generate_bridge_yaml(
+        [base_sdf] + sensor_sdf_paths, bridge_tmp.name
+    )
+
+    # 3) Load the iris_with_sensors model and patch sim_address.
+    sdf_file = os.path.join(
+        pkg_project_description, "models", "iris_with_sensors", "model.sdf"
+    )
+    with open(sdf_file, "r") as infp:
+        robot_desc = infp.read()
+
+    sim_address = LaunchConfiguration("sim_address").perform(context)
+    robot_desc = robot_desc.replace(
+        "<fdm_addr>127.0.0.1</fdm_addr>",
+        f"<fdm_addr>{sim_address}</fdm_addr>",
+    )
+
+    sdf_tmp = tempfile.NamedTemporaryFile(
+        delete=False, suffix="_iris_with_sensors.sdf"
+    )
+    sdf_tmp.write(robot_desc.encode())
+    sdf_tmp.close()
+
+    # 4) Hand over to the shared robot launch file.
+    robot = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                PathJoinSubstitution(
+                    [
+                        pkg_project_bringup,
+                        "launch",
+                        "robots",
+                        "robot.launch.py",
+                    ]
+                ),
+            ]
+        ),
+        launch_arguments={
+            "namespace": LaunchConfiguration("namespace"),
+            "use_gz_tf": LaunchConfiguration("use_gz_tf"),
+            "sdf_file": sdf_tmp.name,
+            "bridge_config_file": bridge_tmp.name,
+            "command": "arducopter",
+            "robot_name": LaunchConfiguration("robot_name"),
+            "world_name": LaunchConfiguration("world_name"),
+            "model": LaunchConfiguration("model"),
+            "defaults": LaunchConfiguration("defaults"),
+            "synthetic_clock": LaunchConfiguration("synthetic_clock"),
+            "sim_address": LaunchConfiguration("sim_address"),
+            "x": LaunchConfiguration("x"),
+            "y": LaunchConfiguration("y"),
+            "z": LaunchConfiguration("z"),
+            "R": LaunchConfiguration("R"),
+            "P": LaunchConfiguration("P"),
+            "Y": LaunchConfiguration("Y"),
+            "instance": LaunchConfiguration("instance"),
+            "sysid": LaunchConfiguration("sysid"),
+            "use_instance_dir": LaunchConfiguration("use_instance_dir"),
+            "use_dds_agent": LaunchConfiguration("use_dds_agent"),
+        }.items(),
+    )
+
+    return [robot]
+
+
+def generate_launch_arguments() -> List[DeclareLaunchArgument]:
+    """Generate a list of launch arguments."""
+    pkg_ardupilot_sitl = get_package_share_directory("ardupilot_sitl")
+
+    return [
+        # ros-args
+        DeclareLaunchArgument(
+            "namespace",
+            default_value="",
+            description="Robot namespace.",
+        ),
+        # sitl_dds
+        DeclareLaunchArgument(
+            "model",
+            default_value="json",
+            description="Set simulation model. Set default to 'json' for Gazebo.",
+        ),
+        DeclareLaunchArgument(
+            "defaults",
+            default_value=(
+                os.path.join(
+                    pkg_ardupilot_sitl,
+                    "config",
+                    "default_params",
+                    "copter.parm",
+                )
+                + ","
+                + os.path.join(
+                    pkg_ardupilot_sitl,
+                    "config",
+                    "default_params",
+                    "gazebo-iris.parm",
+                )
+                + ","
+                + os.path.join(
+                    pkg_ardupilot_sitl,
+                    "config",
+                    "default_params",
+                    "dds_udp.parm",
+                )
+                + ","
+                + os.path.join(
+                    pkg_ardupilot_sitl,
+                    "config",
+                    "default_params",
+                    "dds_use_ns.parm",
+                )
+            ),
+            description="Set path to default params for the iris with DDS.",
+        ),
+        DeclareLaunchArgument(
+            "synthetic_clock",
+            default_value="True",
+        ),
+        DeclareLaunchArgument(
+            "sim_address",
+            default_value="127.0.0.1",
+        ),
+        DeclareLaunchArgument(
+            "instance",
+            default_value="0",
+            description="Set instance of SITL "
+            "(adds 10*instance to all port numbers).",
+        ),
+        DeclareLaunchArgument(
+            "sysid",
+            default_value="",
+            description="Set SYSID_THISMAV.",
+        ),
+        DeclareLaunchArgument(
+            "use_instance_dir",
+            default_value="False",
+            description="If True create instance directories for the eeprom.bin.",
+        ),
+        DeclareLaunchArgument(
+            "use_dds_agent",
+            default_value="True",
+            description="If True launch the micro-ros-agent.",
+        ),
+        # topic_tools_tf
+        DeclareLaunchArgument(
+            "use_gz_tf", default_value="true", description="Use Gazebo TF."
+        ),
+        # bridge, spawn_robot
+        DeclareLaunchArgument(
+            "world_name",
+            default_value="warehouse",
+            description="Name for the world instance.",
+        ),
+        DeclareLaunchArgument(
+            "robot_name",
+            default_value="iris",
+            description="Name for the model instance.",
+        ),
+        DeclareLaunchArgument(
+            "x",
+            default_value="0.0",
+            description="The initial 'x' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "y",
+            default_value="0.0",
+            description="The initial 'y' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "z",
+            default_value="0.2",
+            description="The initial 'z' position (m).",
+        ),
+        DeclareLaunchArgument(
+            "R",
+            default_value="0.0",
+            description="The initial roll angle (radians).",
+        ),
+        DeclareLaunchArgument(
+            "P",
+            default_value="0.0",
+            description="The initial pitch angle (radians).",
+        ),
+        DeclareLaunchArgument(
+            "Y",
+            default_value="0.0",
+            description="The initial yaw angle (radians).",
+        ),
+    ]
+
+
+def generate_launch_description() -> LaunchDescription:
+    """Generate a launch description for an iris quadcopter with sensors."""
+
+    launch_arguments = generate_launch_arguments()
+
+    return LaunchDescription(
+        launch_arguments + [OpaqueFunction(function=generate_robot_launch_actions)]
+    )

--- a/ardupilot_gz_bringup/launch/rviz_generator.py
+++ b/ardupilot_gz_bringup/launch/rviz_generator.py
@@ -1,0 +1,530 @@
+# Copyright 2026 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Generate an RViz config from SDF files.
+
+Reads the same ``<sensor>`` tree that ``bridge_generator`` does and emits
+an ``*.rviz`` config with one RViz display per sensor output (image,
+point cloud, laser scan, etc.) plus the usual Grid/Axes/TF/RobotModel/
+Odometry displays.
+
+Topic names are relative (e.g. ``scan`` rather than ``/iris/scan``) so
+the generated config works correctly when rviz2 is launched under the
+robot namespace.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from bridge_generator import parse_sensors
+
+
+_LIDAR_PALETTE: List[str] = [
+    "239; 83; 80",    # red
+    "38; 198; 218",   # cyan
+    "255; 214; 0",    # yellow
+    "171; 71; 188",   # purple
+    "102; 187; 106",  # green
+    "255; 112; 67",   # orange
+    "66; 165; 245",   # blue
+    "236; 64; 122",   # pink
+]
+
+
+# ---------------------------------------------------------------------------
+# Building blocks for the RViz display tree.
+# ---------------------------------------------------------------------------
+
+def _topic_block(name: str) -> Dict[str, Any]:
+    return {
+        "Depth": 5,
+        "Durability Policy": "Volatile",
+        "Filter size": 10,
+        "History Policy": "Keep Last",
+        "Reliability Policy": "Reliable",
+        "Value": name,
+    }
+
+
+def _grid_display() -> Dict[str, Any]:
+    return {
+        "Alpha": 0.5,
+        "Cell Size": 1,
+        "Class": "rviz_default_plugins/Grid",
+        "Color": "160; 160; 164",
+        "Enabled": True,
+        "Line Style": {"Line Width": 0.03, "Value": "Lines"},
+        "Name": "Grid",
+        "Normal Cell Count": 0,
+        "Offset": {"X": 0, "Y": 0, "Z": 0},
+        "Plane": "XY",
+        "Plane Cell Count": 10,
+        "Reference Frame": "<Fixed Frame>",
+        "Value": True,
+    }
+
+
+def _axes_display() -> Dict[str, Any]:
+    return {
+        "Class": "rviz_default_plugins/Axes",
+        "Enabled": True,
+        "Length": 1.0,
+        "Name": "Axes",
+        "Radius": 0.05,
+        "Reference Frame": "<Fixed Frame>",
+        "Value": True,
+    }
+
+
+def _tf_display() -> Dict[str, Any]:
+    return {
+        "Class": "rviz_default_plugins/TF",
+        "Enabled": True,
+        "Frame Timeout": 15,
+        "Frames": {"All Enabled": True},
+        "Marker Scale": 1,
+        "Name": "TF",
+        "Show Arrows": True,
+        "Show Axes": True,
+        "Show Names": False,
+        "Update Interval": 0,
+        "Value": True,
+    }
+
+
+def _robot_model_display() -> Dict[str, Any]:
+    return {
+        "Alpha": 1,
+        "Class": "rviz_default_plugins/RobotModel",
+        "Collision Enabled": False,
+        "Description File": "",
+        "Description Source": "Topic",
+        "Description Topic": _topic_block("robot_description"),
+        "Enabled": True,
+        "Links": {
+            "All Links Enabled": True,
+            "Expand Joint Details": False,
+            "Expand Link Details": False,
+            "Expand Tree": False,
+            "Link Tree Style": "Links in Alphabetic Order",
+        },
+        "Mass Properties": {"Inertia": False, "Mass": False},
+        "Name": "RobotModel",
+        "TF Prefix": "",
+        "Update Interval": 0,
+        "Value": True,
+        "Visual Enabled": True,
+    }
+
+
+def _odometry_display() -> Dict[str, Any]:
+    return {
+        "Angle Tolerance": 0.1,
+        "Class": "rviz_default_plugins/Odometry",
+        "Covariance": {
+            "Orientation": {
+                "Alpha": 0.5,
+                "Color": "255; 255; 127",
+                "Color Style": "Unique",
+                "Frame": "Local",
+                "Offset": 1,
+                "Scale": 1,
+                "Value": True,
+            },
+            "Position": {
+                "Alpha": 0.3,
+                "Color": "204; 51; 204",
+                "Scale": 1,
+                "Value": True,
+            },
+            "Value": True,
+        },
+        "Enabled": True,
+        "Keep": 100,
+        "Name": "Odometry",
+        "Position Tolerance": 0.1,
+        "Shape": {
+            "Alpha": 1,
+            "Axes Length": 1,
+            "Axes Radius": 0.1,
+            "Color": "255; 25; 255",
+            "Head Length": 0.3,
+            "Head Radius": 0.1,
+            "Shaft Length": 1,
+            "Shaft Radius": 0.05,
+            "Value": "Arrow",
+        },
+        "Topic": _topic_block("odometry"),
+        "Value": True,
+    }
+
+
+def _image_display(name: str, topic: str) -> Dict[str, Any]:
+    return {
+        "Class": "rviz_default_plugins/Image",
+        "Enabled": True,
+        "Max Value": 1,
+        "Median window": 5,
+        "Min Value": 0,
+        "Name": name,
+        "Normalize Range": True,
+        "Topic": _topic_block(topic),
+        "Value": True,
+    }
+
+
+def _point_cloud_display(
+    name: str, topic: str, color: Optional[str] = None
+) -> Dict[str, Any]:
+    return {
+        "Alpha": 1,
+        "Autocompute Intensity Bounds": True,
+        "Autocompute Value Bounds": {
+            "Max Value": 10,
+            "Min Value": -10,
+            "Value": True,
+        },
+        "Axis": "Z",
+        "Channel Name": "intensity",
+        "Class": "rviz_default_plugins/PointCloud2",
+        "Color": color if color else "255; 255; 255",
+        "Color Transformer": "FlatColor" if color else "Intensity",
+        "Decay Time": 0,
+        "Enabled": True,
+        "Invert Rainbow": False,
+        "Max Color": "255; 255; 255",
+        "Max Intensity": 0,
+        "Min Color": "0; 0; 0",
+        "Min Intensity": 0,
+        "Name": name,
+        "Position Transformer": "XYZ",
+        "Selectable": True,
+        "Size (Pixels)": 3,
+        "Size (m)": 0.01,
+        "Style": "Flat Squares",
+        "Topic": _topic_block(topic),
+        "Use Fixed Frame": True,
+        "Use rainbow": True,
+        "Value": True,
+    }
+
+
+def _laser_scan_display(
+    name: str, topic: str, color: Optional[str] = None
+) -> Dict[str, Any]:
+    return {
+        "Alpha": 1,
+        "Autocompute Intensity Bounds": True,
+        "Autocompute Value Bounds": {
+            "Max Value": 10,
+            "Min Value": -10,
+            "Value": True,
+        },
+        "Axis": "Z",
+        "Channel Name": "intensity",
+        "Class": "rviz_default_plugins/LaserScan",
+        "Color": color if color else "255; 255; 255",
+        "Color Transformer": "FlatColor" if color else "Intensity",
+        "Decay Time": 0,
+        "Enabled": True,
+        "Invert Rainbow": False,
+        "Max Color": "255; 255; 255",
+        "Max Intensity": 0,
+        "Min Color": "0; 0; 0",
+        "Min Intensity": 0,
+        "Name": name,
+        "Position Transformer": "XYZ",
+        "Selectable": True,
+        "Size (Pixels)": 3,
+        "Size (m)": 0.01,
+        "Style": "Flat Squares",
+        "Topic": _topic_block(topic),
+        "Use Fixed Frame": True,
+        "Use rainbow": True,
+        "Value": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Sensor-type -> displays mapping.
+# ---------------------------------------------------------------------------
+
+def _sensor_displays(
+    sensor: Dict[str, str], color: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    name = sensor["sensor"]
+    kind = sensor["type"]
+    if kind in ("camera", "rgbd_camera", "depth_camera"):
+        displays = [_image_display(f"{name}/image", f"{name}/image")]
+        if kind in ("rgbd_camera", "depth_camera"):
+            displays.append(
+                _image_display(f"{name}/depth_image", f"{name}/depth_image")
+            )
+            displays.append(
+                _point_cloud_display(f"{name}/points", f"{name}/points")
+            )
+        return displays
+    if kind in ("gpu_lidar", "lidar"):
+        return [
+            _laser_scan_display(f"{name}/scan", f"{name}/scan", color),
+            _point_cloud_display(
+                f"{name}/points", f"{name}/scan/points", color
+            ),
+        ]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Top-level assembly.
+# ---------------------------------------------------------------------------
+
+def _panels() -> List[Dict[str, Any]]:
+    return [
+        {
+            "Class": "rviz_common/Displays",
+            "Help Height": 0,
+            "Name": "Displays",
+            "Property Tree Widget": {
+                "Expanded": ["/Global Options1", "/Status1"],
+                "Splitter Ratio": 0.5,
+            },
+            "Tree Height": 587,
+        },
+        {"Class": "rviz_common/Selection", "Name": "Selection"},
+        {
+            "Class": "rviz_common/Tool Properties",
+            "Expanded": ["/2D Goal Pose1", "/Publish Point1"],
+            "Name": "Tool Properties",
+            "Splitter Ratio": 0.5886790156364441,
+        },
+        {
+            "Class": "rviz_common/Views",
+            "Expanded": ["/Current View1"],
+            "Name": "Views",
+            "Splitter Ratio": 0.5,
+        },
+        {
+            "Class": "rviz_common/Time",
+            "Experimental": False,
+            "Name": "Time",
+            "SyncMode": 0,
+            "SyncSource": "",
+        },
+    ]
+
+
+def _tools() -> List[Dict[str, Any]]:
+    return [
+        {"Class": "rviz_default_plugins/Interact", "Hide Inactive Objects": True},
+        {"Class": "rviz_default_plugins/MoveCamera"},
+        {"Class": "rviz_default_plugins/Select"},
+        {"Class": "rviz_default_plugins/FocusCamera"},
+        {
+            "Class": "rviz_default_plugins/Measure",
+            "Line color": "128; 128; 0",
+        },
+        {
+            "Class": "rviz_default_plugins/SetInitialPose",
+            "Covariance x": 0.25,
+            "Covariance y": 0.25,
+            "Covariance yaw": 0.06853891909122467,
+            "Topic": _topic_block("initialpose"),
+        },
+        {
+            "Class": "rviz_default_plugins/SetGoal",
+            "Topic": _topic_block("goal_pose"),
+        },
+        {
+            "Class": "rviz_default_plugins/PublishPoint",
+            "Single click": True,
+            "Topic": _topic_block("clicked_point"),
+        },
+    ]
+
+
+def _views() -> Dict[str, Any]:
+    return {
+        "Current": {
+            "Class": "rviz_default_plugins/Orbit",
+            "Distance": 9.58,
+            "Enable Stereo Rendering": {
+                "Stereo Eye Separation": 0.06,
+                "Stereo Focal Distance": 1,
+                "Swap Stereo Eyes": False,
+                "Value": False,
+            },
+            "Focal Point": {"X": 0.0, "Y": 0.0, "Z": 0.0},
+            "Focal Shape Fixed Size": True,
+            "Focal Shape Size": 0.05,
+            "Invert Z Axis": False,
+            "Name": "Current View",
+            "Near Clip Distance": 0.01,
+            "Pitch": 0.69,
+            "Target Frame": "<Fixed Frame>",
+            "Value": "Orbit (rviz)",
+            "Yaw": 5.1,
+        },
+        "Saved": None,
+    }
+
+
+# Qt-serialised dock layout. rviz2 crashes in libX11 / ogre1 on resize
+# when an Image/Camera display has to materialise a dock at runtime with
+# no saved state to restore. Shipping a canonical blob with an "Image" dock
+# slot is enough to stabilise the startup sequence even for displays whose
+# names are not literally encoded in the blob - Qt docks everything
+# else tabbed alongside.
+_QMAINWINDOW_STATE_BLOB = (
+    "000000ff00000000fd0000000400000000000001630000029afc0200000009"
+    "fb0000001200530065006c0065006300740069006f006e00000001e10000009b"
+    "0000006200fffffffb0000001e0054006f006f006c002000500072006f007000"
+    "650072007400690065007302000001ed000001df00000185000000a3fb000000"
+    "120056006900650077007300200054006f006f02000001df0000021100000185"
+    "00000122fb000000200054006f006f006c002000500072006f00700065007200"
+    "74006900650073003203000002880000011d000002210000017afb0000001000"
+    "44006900730070006c006100790073010000002c0000016f000000e300ffffff"
+    "fb0000002000730065006c0065006300740069006f006e0020006200750066006"
+    "6006500720200000138000000aa0000023a00000294fb000000140057006900640"
+    "06500530074006500720065006f02000000e6000000d2000003ee0000030bfb00"
+    "00000c004b0069006e0065006300740200000186000001060000030c00000261f"
+    "b0000000a0049006d006100670065010000019c0000012a0000003000ffffff00"
+    "0000010000010f0000029bfc0200000003fb0000001e0054006f006f006c00200"
+    "0500072006f00700065007200740069006500730100000041000000780000000000"
+    "000000fb0000000a00560069006500770073000000002c0000029b000000c600ff"
+    "fffffb0000001200530065006c0065006300740069006f006e010000025a000000"
+    "b200000000000000000000000200000490000000a9fc0100000001fb0000000a00"
+    "560069006500770073030000004e00000080000002e10000019700000003000004"
+    "b00000003efc0100000002fb0000000800540069006d00650100000000000004b0"
+    "0000023d00fffffffb0000000800540069006d006501000000000000045000000000"
+    "000000000000034c0000029a00000004000000040000000800000008fc000000010"
+    "0000002000000010000000a0054006f006f006c00730100000000ffffffff000000"
+    "0000000000"
+)
+
+
+def _window_geometry(extra_docks: List[str] = ()) -> Dict[str, Any]:
+    geom: Dict[str, Any] = {
+        "Displays": {"collapsed": False},
+        "Height": 800,
+        "Hide Left Dock": False,
+        "Hide Right Dock": False,
+        "QMainWindow State": _QMAINWINDOW_STATE_BLOB,
+        "Selection": {"collapsed": False},
+        "Time": {"collapsed": False},
+        "Tool Properties": {"collapsed": False},
+        "Views": {"collapsed": False},
+        "Width": 1200,
+        "X": 0,
+        "Y": 38,
+    }
+    for dock in extra_docks:
+        geom[dock] = {"collapsed": False}
+    return geom
+
+
+def generate_rviz_config(
+    sdf_files: List[str],
+    output_path: str,
+    fixed_frame: str = "odom",
+) -> str:
+    """Parse sensors from ``sdf_files`` and emit an rviz2 config yaml."""
+    all_sensors: List[Dict[str, str]] = []
+    seen = set()
+    for sdf in sdf_files:
+        for s in parse_sensors(sdf):
+            key = (s["link"], s["sensor"], s["type"])
+            if key in seen:
+                continue
+            seen.add(key)
+            all_sensors.append(s)
+
+    robot_group_displays: List[Dict[str, Any]] = [
+        _grid_display(),
+        _axes_display(),
+        _robot_model_display(),
+        _tf_display(),
+        _odometry_display(),
+    ]
+
+    # If there's more than one lidar, give each a distinct flat colour so
+    # their point clouds/scans are visually separable in rviz. A single
+    # lidar keeps the default intensity-based colouring.
+    lidar_sensors = [
+        s for s in all_sensors if s["type"] in ("gpu_lidar", "lidar")
+    ]
+    lidar_colors: Dict[str, str] = {}
+    if len(lidar_sensors) > 1:
+        for idx, s in enumerate(lidar_sensors):
+            lidar_colors[s["sensor"]] = _LIDAR_PALETTE[idx % len(_LIDAR_PALETTE)]
+
+    sensor_group_displays: List[Dict[str, Any]] = []
+    image_dock_names: List[str] = []
+    for sensor in all_sensors:
+        color = lidar_colors.get(sensor["sensor"])
+        for display in _sensor_displays(sensor, color):
+            sensor_group_displays.append(display)
+            if display["Class"] == "rviz_default_plugins/Image":
+                image_dock_names.append(display["Name"])
+
+    displays: List[Dict[str, Any]] = [
+        {
+            "Class": "rviz_common/Group",
+            "Displays": robot_group_displays,
+            "Enabled": True,
+            "Name": "Robot",
+        }
+    ]
+    if sensor_group_displays:
+        displays.append(
+            {
+                "Class": "rviz_common/Group",
+                "Displays": sensor_group_displays,
+                "Enabled": True,
+                "Name": "Sensors",
+            }
+        )
+
+    config: Dict[str, Any] = {
+        "Panels": _panels(),
+        "Visualization Manager": {
+            "Class": "",
+            "Displays": displays,
+            "Enabled": True,
+            "Global Options": {
+                "Background Color": "48; 48; 48",
+                "Fixed Frame": fixed_frame,
+                "Frame Rate": 30,
+            },
+            "Name": "root",
+            "Tools": _tools(),
+            "Transformation": {
+                "Current": {"Class": "rviz_default_plugins/TF"},
+            },
+            "Value": True,
+            "Views": _views(),
+        },
+        "Window Geometry": _window_geometry(image_dock_names),
+    }
+
+    header = (
+        "# This file is auto-generated by rviz_generator.py.\n"
+        "# Do not edit: changes are overwritten each time the launch runs.\n"
+    )
+    with open(output_path, "w") as f:
+        f.write(header)
+        yaml.safe_dump(config, f, default_flow_style=False, sort_keys=False)
+    return output_path

--- a/ardupilot_gz_bringup/package.xml
+++ b/ardupilot_gz_bringup/package.xml
@@ -23,6 +23,7 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>sdformat_urdf</exec_depend>
   <exec_depend>topic_tools</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/ardupilot_gz_description/models/camera/model.config
+++ b/ardupilot_gz_description/models/camera/model.config
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Camera</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+
+  <author>
+    <name>Gilbert Tanner</name>
+    <email>gilberttanner.contact@gmail.com</email>
+  </author>
+
+  <maintainer email="gilberttanner.contact@gmail.com">Gilbert Tanner</maintainer>
+
+  <description>
+    Camera sensor generated through xacro macro
+  </description>
+</model>

--- a/ardupilot_gz_description/models/camera/model.xacro
+++ b/ardupilot_gz_description/models/camera/model.xacro
@@ -1,0 +1,154 @@
+<?xml version="1.0"?>
+<sdf version="1.9" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <model name="cameras">
+    <static>true</static>
+    <link name="cameras_link">
+      <pose>0 0 0 0 0 0</pose>
+      <kinematic>true</kinematic>
+      <gravity>false</gravity>
+      <inertial>
+        <mass>0.0</mass>
+        <inertia>
+          <ixx>0.0</ixx>
+          <ixy>0.0</ixy>
+          <iyy>0.0</iyy>
+          <iyz>0.0</iyz>
+          <izz>0.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+
+    <!-- Macro Definition for Camera -->
+    <xacro:macro name="camera_sensor"
+      params="name pose optical_pose horizontal_fov image_width image_height update_rate format intrinsics:='277 277 160 120' distortion:='0.0 0.0 0.0 0.0'">
+      <xacro:property name="fx" value="${intrinsics.split()[0]}" />
+      <xacro:property name="fy" value="${intrinsics.split()[1]}" />
+      <xacro:property name="cx" value="${intrinsics.split()[2]}" />
+      <xacro:property name="cy" value="${intrinsics.split()[3]}" />
+
+      <xacro:property name="k1" value="${distortion.split()[0]}" />
+      <xacro:property name="k2" value="${distortion.split()[1]}" />
+      <xacro:property name="p1" value="${distortion.split()[2]}" />
+      <xacro:property name="p2" value="${distortion.split()[3]}" />
+      <link name="${name}_link">
+        <pose>${pose}</pose>
+        <kinematic>true</kinematic>
+        <gravity>false</gravity>
+
+        <inertial>
+          <mass>0.0</mass>
+          <inertia>
+            <ixx>0.0</ixx>
+            <ixy>0.0</ixy>
+            <iyy>0.0</iyy>
+            <iyz>0.0</iyz>
+            <izz>0.0</izz>
+          </inertia>
+        </inertial>
+
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.05 0.05 0.05</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+          </material>
+        </visual>
+
+        <visual name="landmark">
+          <geometry>
+            <cylinder>
+              <radius>0.01</radius>
+              <length>0.005</length>
+            </cylinder>
+          </geometry>
+          <pose>0.03 0 0 0 1.5708 0</pose>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+          </material>
+        </visual>
+
+        <sensor name="${name}" type="camera">
+          <gz_frame_id>${name}_optical_frame</gz_frame_id>
+          <pose>0 0 0 0 0 0</pose>
+          <camera>
+            <horizontal_fov>${horizontal_fov}</horizontal_fov>
+            <image>
+              <width>${image_width}</width>
+              <height>${image_height}</height>
+              <format>${format}</format>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100.0</far>
+            </clip>
+            <lens>
+              <intrinsics>
+                <fx>${fx}</fx>
+                <fy>${fy}</fy>
+                <cx>${cx}</cx>
+                <cy>${cy}</cy>
+                <s>0</s>
+              </intrinsics>
+            </lens>
+            <distortion>
+              <k1>${k1}</k1>
+              <k2>${k2}</k2>
+              <k3>0.0</k3>
+              <p1>${p1}</p1>
+              <p2>${p2}</p2>
+              <center>0.5 0.5</center>
+            </distortion>
+          </camera>
+          <update_rate>${update_rate}</update_rate>
+          <visualize>false</visualize>
+        </sensor>
+      </link>
+
+      <link name="${name}_optical_frame">
+        <pose>${optical_pose}</pose>
+        <kinematic>true</kinematic>
+        <gravity>false</gravity>
+
+        <inertial>
+          <mass>0.0</mass>
+          <inertia>
+            <ixx>0.0</ixx>
+            <ixy>0.0</ixy>
+            <iyy>0.0</iyy>
+            <iyz>0.0</iyz>
+            <izz>0.0</izz>
+          </inertia>
+        </inertial>
+      </link>
+
+      <joint name="${name}_optical_joint" type="fixed">
+        <parent>${name}_link</parent>
+        <child>${name}_optical_frame</child>
+      </joint>
+
+      <joint name="${name}_joint" type="fixed">
+        <parent>cameras_link</parent>
+        <child>${name}_link</child>
+        <preserve_fixed_joint>true</preserve_fixed_joint>
+      </joint>
+    </xacro:macro>
+
+    <!-- Add Camera Sensors -->
+    <xacro:camera_sensor
+      name="navigation_camera"
+      pose="-0.05 -0.02 -0.05 0 1.57 0"
+      optical_pose="-0.05 -0.02 -0.05 0 3.14 1.57"
+      horizontal_fov="1.448"
+      intrinsics="471.42701287242807 470.7784450086591 389.70874283839333 258.6696297186715"
+      distortion="-0.3141061887234863 0.12230478626307012 -0.00010883202540227276 -0.0003551641298941904"
+      image_width="752"
+      image_height="480"
+      update_rate="50"
+      format="L_INT8" />
+  </model>
+</sdf>

--- a/ardupilot_gz_description/models/depth_camera/model.config
+++ b/ardupilot_gz_description/models/depth_camera/model.config
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Depth Camera</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+
+  <author>
+    <name>Gilbert Tanner</name>
+    <email>gilberttanner.contact@gmail.com</email>
+  </author>
+
+  <maintainer email="gilberttanner.contact@gmail.com">Gilbert Tanner</maintainer>
+
+  <description>
+    Depth camera sensor generated through xacro macro
+  </description>
+</model>

--- a/ardupilot_gz_description/models/depth_camera/model.xacro
+++ b/ardupilot_gz_description/models/depth_camera/model.xacro
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<sdf version="1.9" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <model name="depth_cameras">
+    <static>true</static>
+    <link name="depth_cameras_link">
+      <pose>0 0 0 0 0 0</pose>
+      <kinematic>true</kinematic>
+      <gravity>false</gravity>
+      <inertial>
+        <mass>0.0</mass>
+        <inertia>
+          <ixx>0.0</ixx>
+          <ixy>0.0</ixy>
+          <iyy>0.0</iyy>
+          <iyz>0.0</iyz>
+          <izz>0.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+
+    <!-- Macro Definition for Depth Camera -->
+    <xacro:macro name="depth_camera_sensor"
+      params="name pose horizontal_fov image_width image_height update_rate">
+      <link name="${name}_link">
+        <pose>${pose}</pose>
+        <kinematic>true</kinematic>
+        <gravity>false</gravity>
+
+        <inertial>
+          <mass>0.0</mass>
+          <inertia>
+            <ixx>0.0</ixx>
+            <ixy>0.0</ixy>
+            <iyy>0.0</iyy>
+            <iyz>0.0</iyz>
+            <izz>0.0</izz>
+          </inertia>
+        </inertial>
+
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.05 0.05 0.05</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+          </material>
+        </visual>
+
+        <visual name="landmark">
+          <geometry>
+            <cylinder>
+              <radius>0.01</radius>
+              <length>0.005</length>
+            </cylinder>
+          </geometry>
+          <pose>0.03 0 0 0 1.5708 0</pose>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+          </material>
+        </visual>
+
+        <sensor name="${name}" type="depth_camera">
+          <gz_frame_id>${name}_link</gz_frame_id>
+          <pose>0 0 0 0 0 0</pose>
+          <camera>
+            <horizontal_fov>${horizontal_fov}</horizontal_fov>
+            <image>
+              <width>${image_width}</width>
+              <height>${image_height}</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100.0</far>
+            </clip>
+          </camera>
+          <update_rate>${update_rate}</update_rate>
+          <visualize>false</visualize>
+        </sensor>
+      </link>
+
+      <joint name="${name}_joint" type="fixed">
+        <parent>depth_cameras_link</parent>
+        <child>${name}_link</child>
+        <preserve_fixed_joint>true</preserve_fixed_joint>
+      </joint>
+    </xacro:macro>
+  </model>
+</sdf>

--- a/ardupilot_gz_description/models/iris_with_sensors/model.config
+++ b/ardupilot_gz_description/models/iris_with_sensors/model.config
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Iris with sensors</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+
+  <description>
+    Iris quadcopter (from `iris_with_standoffs`) combined with xacro-generated
+    lidar, camera, depth_camera, and rgbd_camera sensor models.
+  </description>
+  <depend>
+    <model>
+      <uri>model://iris_with_standoffs</uri>
+      <version>1.0</version>
+    </model>
+    <model>
+      <uri>model://lidar</uri>
+      <version>1.0</version>
+    </model>
+    <model>
+      <uri>model://camera</uri>
+      <version>1.0</version>
+    </model>
+    <model>
+      <uri>model://depth_camera</uri>
+      <version>1.0</version>
+    </model>
+    <model>
+      <uri>model://rgbd_camera</uri>
+      <version>1.0</version>
+    </model>
+  </depend>
+</model>

--- a/ardupilot_gz_description/models/iris_with_sensors/model.sdf
+++ b/ardupilot_gz_description/models/iris_with_sensors/model.sdf
@@ -1,0 +1,322 @@
+<?xml version='1.0'?>
+<sdf version="1.9">
+
+  <model name="iris_with_sensors">
+    <include merge="true">
+      <uri>model://iris_with_standoffs</uri>
+    </include>
+
+    <plugin filename="gz-sim-joint-state-publisher-system"
+      name="gz::sim::systems::JointStatePublisher">
+    </plugin>
+
+    <plugin
+      filename="gz-sim-odometry-publisher-system"
+      name="gz::sim::systems::OdometryPublisher">
+      <odom_frame>odom</odom_frame>
+      <robot_base_frame>base_link</robot_base_frame>
+      <dimensions>3</dimensions>
+    </plugin>
+
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.0</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>0.084 0 0</cp>
+      <forward>0 1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>rotor_0</link_name>
+    </plugin>
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.0</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>-0.084 0 0</cp>
+      <forward>0 -1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>rotor_0</link_name>
+    </plugin>
+
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.0</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>0.084 0 0</cp>
+      <forward>0 1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>rotor_1</link_name>
+    </plugin>
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.0</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>-0.084 0 0</cp>
+      <forward>0 -1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>rotor_1</link_name>
+    </plugin>
+
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.0</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>0.084 0 0</cp>
+      <forward>0 -1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>rotor_2</link_name>
+    </plugin>
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.0</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>-0.084 0 0</cp>
+      <forward>0 1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>rotor_2</link_name>
+    </plugin>
+
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.0</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>0.084 0 0</cp>
+      <forward>0 -1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>rotor_3</link_name>
+    </plugin>
+    <plugin filename="gz-sim-lift-drag-system"
+        name="gz::sim::systems::LiftDrag">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.0</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>-0.084 0 0</cp>
+      <forward>0 1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>rotor_3</link_name>
+    </plugin>
+
+    <plugin filename="gz-sim-apply-joint-force-system"
+      name="gz::sim::systems::ApplyJointForce">
+      <joint_name>rotor_0_joint</joint_name>
+    </plugin>
+    <plugin filename="gz-sim-apply-joint-force-system"
+      name="gz::sim::systems::ApplyJointForce">
+      <joint_name>rotor_1_joint</joint_name>
+    </plugin>
+    <plugin filename="gz-sim-apply-joint-force-system"
+      name="gz::sim::systems::ApplyJointForce">
+      <joint_name>rotor_2_joint</joint_name>
+    </plugin>
+    <plugin filename="gz-sim-apply-joint-force-system"
+      name="gz::sim::systems::ApplyJointForce">
+      <joint_name>rotor_3_joint</joint_name>
+    </plugin>
+
+    <plugin filename="gz-sim-linearbatteryplugin-system"
+      name="gz::sim::systems::LinearBatteryPlugin">
+      <battery_name>lipo_3500mAh</battery_name>
+      <fix_issue_225>true</fix_issue_225>
+      <open_circuit_voltage_constant_coef>12.6</open_circuit_voltage_constant_coef>
+      <open_circuit_voltage_linear_coef>-2.7</open_circuit_voltage_linear_coef>
+      <capacity>3.5</capacity>
+      <voltage>12.6</voltage>
+      <initial_charge>3.5</initial_charge>
+      <power_load>200.0</power_load>
+      <start_draining>false</start_draining>
+    </plugin>
+
+    <plugin name="ArduPilotPlugin"
+      filename="ArduPilotPlugin">
+      <fdm_addr>127.0.0.1</fdm_addr>
+      <fdm_port_in>9002</fdm_port_in>
+      <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
+      <lock_step>1</lock_step>
+
+      <!-- Frame conventions
+        Require by ArduPilot: change model and gazebo from XYZ to XY-Z coordinates
+      -->
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
+
+      <!-- Sensors -->
+      <imuName>imu_link::imu_sensor</imuName>
+
+      <!-- Control channels -->
+      <control channel="0">
+        <jointName>rotor_0_joint</jointName>
+        <useForce>1</useForce>
+        <multiplier>838</multiplier>
+        <offset>0</offset>
+        <servo_min>1100</servo_min>
+        <servo_max>1900</servo_max>
+        <type>VELOCITY</type>
+        <p_gain>0.20</p_gain>
+        <i_gain>0</i_gain>
+        <d_gain>0</d_gain>
+        <i_max>0</i_max>
+        <i_min>0</i_min>
+        <cmd_max>2.5</cmd_max>
+        <cmd_min>-2.5</cmd_min>
+        <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
+      </control>
+
+      <control channel="1">
+        <jointName>rotor_1_joint</jointName>
+        <useForce>1</useForce>
+        <multiplier>838</multiplier>
+        <offset>0</offset>
+        <servo_min>1100</servo_min>
+        <servo_max>1900</servo_max>
+        <type>VELOCITY</type>
+        <p_gain>0.20</p_gain>
+        <i_gain>0</i_gain>
+        <d_gain>0</d_gain>
+        <i_max>0</i_max>
+        <i_min>0</i_min>
+        <cmd_max>2.5</cmd_max>
+        <cmd_min>-2.5</cmd_min>
+        <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
+      </control>
+
+      <control channel="2">
+        <jointName>rotor_2_joint</jointName>
+        <useForce>1</useForce>
+        <multiplier>-838</multiplier>
+        <offset>0</offset>
+        <servo_min>1100</servo_min>
+        <servo_max>1900</servo_max>
+        <type>VELOCITY</type>
+        <p_gain>0.20</p_gain>
+        <i_gain>0</i_gain>
+        <d_gain>0</d_gain>
+        <i_max>0</i_max>
+        <i_min>0</i_min>
+        <cmd_max>2.5</cmd_max>
+        <cmd_min>-2.5</cmd_min>
+        <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
+      </control>
+
+      <control channel="3">
+        <jointName>rotor_3_joint</jointName>
+        <useForce>1</useForce>
+        <multiplier>-838</multiplier>
+        <offset>0</offset>
+        <servo_min>1100</servo_min>
+        <servo_max>1900</servo_max>
+        <type>VELOCITY</type>
+        <p_gain>0.20</p_gain>
+        <i_gain>0</i_gain>
+        <d_gain>0</d_gain>
+        <i_max>0</i_max>
+        <i_min>0</i_min>
+        <cmd_max>2.5</cmd_max>
+        <cmd_min>-2.5</cmd_min>
+        <controlVelocitySlowdownSim>1</controlVelocitySlowdownSim>
+      </control>
+    </plugin>
+
+    <include merge="true">
+      <uri>model://lidar</uri>
+    </include>
+
+    <joint name="lidars_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>lidars_link</child>
+      <preserve_fixed_joint>true</preserve_fixed_joint>
+    </joint>
+
+    <include merge="true">
+      <uri>model://camera</uri>
+    </include>
+
+    <joint name="cameras_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>cameras_link</child>
+      <preserve_fixed_joint>true</preserve_fixed_joint>
+    </joint>
+
+    <include merge="true">
+      <uri>model://depth_camera</uri>
+    </include>
+
+    <joint name="depth_cameras_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>depth_cameras_link</child>
+      <preserve_fixed_joint>true</preserve_fixed_joint>
+    </joint>
+
+    <include merge="true">
+      <uri>model://rgbd_camera</uri>
+    </include>
+
+    <joint name="rgbd_cameras_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>rgbd_cameras_link</child>
+      <preserve_fixed_joint>true</preserve_fixed_joint>
+    </joint>
+  </model>
+
+</sdf>

--- a/ardupilot_gz_description/models/lidar/model.config
+++ b/ardupilot_gz_description/models/lidar/model.config
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Lidar</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+
+  <author>
+    <name>Gilbert Tanner</name>
+    <email>gilberttanner.contact@gmail.com</email>
+  </author>
+
+  <maintainer email="gilberttanner.contact@gmail.com">Gilbert Tanner</maintainer>
+
+  <description>
+    3D LiDaR sensor generated through xacro macro
+  </description>
+</model>

--- a/ardupilot_gz_description/models/lidar/model.xacro
+++ b/ardupilot_gz_description/models/lidar/model.xacro
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+<sdf version="1.9" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <model name="lidars">
+    <static>true</static>
+    <link name="lidars_link">
+      <pose>0 0 0 0 0 0</pose>
+      <kinematic>true</kinematic>
+      <gravity>false</gravity>
+      <inertial>
+        <mass>0.0</mass>
+        <inertia>
+          <ixx>0.0</ixx>
+          <ixy>0.0</ixy>
+          <iyy>0.0</iyy>
+          <iyz>0.0</iyz>
+          <izz>0.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+
+    <!-- Macro Definition for LiDAR -->
+    <xacro:macro name="lidar_sensor"
+      params="name pose horizontal_fov vertical_fov horizontal_samples vertical_samples update_rate">
+      <link name="${name}_link">
+        <pose>${pose}</pose>
+        <kinematic>true</kinematic>
+        <gravity>false</gravity>
+
+        <inertial>
+          <mass>0.0</mass>
+          <inertia>
+            <ixx>0.0</ixx>
+            <ixy>0.0</ixy>
+            <iyy>0.0</iyy>
+            <iyz>0.0</iyz>
+            <izz>0.0</izz>
+          </inertia>
+        </inertial>
+
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.05 0.05 0.05</size>
+            </box>
+          </geometry>
+        </visual>
+
+        <visual name="landmark">
+          <geometry>
+            <cylinder>
+              <radius>0.01</radius>
+              <length>0.005</length>
+            </cylinder>
+          </geometry>
+          <pose>0.03 0 0 0 1.5708 0</pose>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+          </material>
+        </visual>
+
+        <sensor name="${name}" type="gpu_lidar">
+          <gz_frame_id>${name}_link</gz_frame_id>
+          <pose>0 0 0 0 0 0</pose>
+          <update_rate>${update_rate}</update_rate>
+          <lidar>
+            <scan>
+              <horizontal>
+                <samples>${horizontal_samples}</samples>
+                <resolution>1</resolution>
+                <min_angle>-${horizontal_fov}</min_angle>
+                <max_angle>${horizontal_fov}</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>${vertical_samples}</samples>
+                <resolution>1</resolution>
+                <min_angle>-${vertical_fov}</min_angle>
+                <max_angle>${vertical_fov}</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>0.45</min>
+              <max>50.0</max>
+              <resolution>0.001</resolution>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>0.01</stddev>
+              <bias_mean>0.0</bias_mean>
+              <bias_stddev>0.001</bias_stddev>
+            </noise>
+          </lidar>
+          <visualize>false</visualize>
+        </sensor>
+      </link>
+
+      <joint name="${name}_joint" type="fixed">
+        <parent>lidars_link</parent>
+        <child>${name}_link</child>
+        <preserve_fixed_joint>true</preserve_fixed_joint>
+      </joint>
+    </xacro:macro>
+
+    <!-- Add LiDAR sensors -->
+    <xacro:lidar_sensor name="lidar_1" pose="0.12 0.02 0.0 0 1.57 0" horizontal_fov="3.14159"
+      vertical_fov="0.785398" horizontal_samples="512" vertical_samples="128" update_rate="20" />
+  </model>
+</sdf>

--- a/ardupilot_gz_description/models/rgbd_camera/model.config
+++ b/ardupilot_gz_description/models/rgbd_camera/model.config
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>RGBD Camera</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+
+  <description>
+    RGBD camera sensor(s) attached to a `rgbd_cameras_link` frame. Generated from `model.xacro`.
+  </description>
+</model>

--- a/ardupilot_gz_description/models/rgbd_camera/model.xacro
+++ b/ardupilot_gz_description/models/rgbd_camera/model.xacro
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<sdf version="1.9" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <model name="rgbd_cameras">
+    <static>true</static>
+    <link name="rgbd_cameras_link">
+      <pose>0 0 0 0 0 0</pose>
+      <kinematic>true</kinematic>
+      <gravity>false</gravity>
+      <inertial>
+        <mass>0.0</mass>
+        <inertia>
+          <ixx>0.0</ixx>
+          <ixy>0.0</ixy>
+          <iyy>0.0</iyy>
+          <iyz>0.0</iyz>
+          <izz>0.0</izz>
+        </inertia>
+      </inertial>
+    </link>
+
+    <!-- Macro Definition for RGBD Camera -->
+    <xacro:macro name="rgbd_camera_sensor"
+      params="name pose horizontal_fov image_width image_height update_rate">
+      <link name="${name}_link">
+        <pose>${pose}</pose>
+        <kinematic>true</kinematic>
+        <gravity>false</gravity>
+
+        <inertial>
+          <mass>0.0</mass>
+          <inertia>
+            <ixx>0.0</ixx>
+            <ixy>0.0</ixy>
+            <iyy>0.0</iyy>
+            <iyz>0.0</iyz>
+            <izz>0.0</izz>
+          </inertia>
+        </inertial>
+
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.05 0.05 0.05</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+          </material>
+        </visual>
+
+        <visual name="landmark">
+          <geometry>
+            <cylinder>
+              <radius>0.01</radius>
+              <length>0.005</length>
+            </cylinder>
+          </geometry>
+          <pose>0.03 0 0 0 1.5708 0</pose>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+          </material>
+        </visual>
+
+        <sensor name="${name}" type="rgbd_camera">
+          <gz_frame_id>${name}_link</gz_frame_id>
+          <pose>0 0 0 0 0 0</pose>
+          <camera>
+            <horizontal_fov>${horizontal_fov}</horizontal_fov>
+            <image>
+              <width>${image_width}</width>
+              <height>${image_height}</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100.0</far>
+            </clip>
+          </camera>
+          <update_rate>${update_rate}</update_rate>
+          <visualize>false</visualize>
+        </sensor>
+      </link>
+
+      <joint name="${name}_joint" type="fixed">
+        <parent>rgbd_cameras_link</parent>
+        <child>${name}_link</child>
+        <preserve_fixed_joint>true</preserve_fixed_joint>
+      </joint>
+    </xacro:macro>
+  </model>
+</sdf>


### PR DESCRIPTION
## Goal

Create a system that allows for easy changes to drone sensors through XACRO. Could replace separate models and launch files like #91.

## Summary

- Add `iris_with_sensors` Iris variant in `ardupilot_gz_description` built on top  `iris_with_standoffs`, with its camera, depth_camera, lidar, and rgbd_camera authored as `model.xacro` macros (ported from https://github.com/TannerGilbert/Ardupilot_Multiagent_Simulation).                                                                                 
- Add `iris_with_sensors_warehouse.launch.py` + `robots/iris_with_sensors.launch.py`, to run `xacro` at launch time to generate each sensor's `model.sdf`, so editing the xacro (adding/removing/renaming a sensor) flows through without                                                                        
  touching any yaml by hand.                                                                                                                         
- Add `bridge_generator.py` and `rviz_generator.py`: parse the generated sensor SDFs + `iris_with_standoffs` and emit a matching `ros_gz_bridge` yaml and rviz2 config on every launch. The xacro is the single source of truth and the bridge topics and rviz displays stay in sync automatically.                                                                                               
                                                                                                                                                     
## Design notes            
- The bridge-yaml template variables `{{ world_name }}` / `{{ robot_name }}` are the same ones `robot.launch.py::replace_robot_name` already substitutes, so the generated yaml plugs into the existing pipeline unchanged.                                                                                         
- rviz config notes:                                                                                                                                                                                                      
  - When more than one lidar is present, each gets a distinct flat colour from an 8-entry palette so point clouds / scans are visually separable. A single lidar keeps intensity-based colouring.                                                                                                           

<img width="3840" height="2160" alt="Screenshot from 2026-04-24 19-46-05" src="https://github.com/user-attachments/assets/6c504314-9cae-4ecf-b61c-a3a40c96795a" />
