### PR TITLE
Add ardupilot namespace support for clock sync

### DIFF
--- a/ardupilot_gz_bringup/launch/alti_transition_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/alti_transition_runway.launch.py
@@ -49,6 +49,9 @@ def generate_launch_description():
                 ),
             ]
         ),
+        launch_arguments={
+            "use_ap_namespace": LaunchConfiguration("use_ap_namespace"),
+        }.items(),
         condition=IfCondition(LaunchConfiguration("spawn_robot")),
     )
 
@@ -91,6 +94,11 @@ def generate_launch_description():
                 "namespace",
                 default_value="",
                 description="Robot namespace.",
+            ),
+            DeclareLaunchArgument(
+                "use_ap_namespace",
+                default_value="true",
+                description="If True, use namespaces for ardupilot clock sync (e.g. /ap/vN/clock)",
             ),
             DeclareLaunchArgument(
                 "use_gz_sim_server",

--- a/ardupilot_gz_bringup/launch/iris_maze.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_maze.launch.py
@@ -61,6 +61,9 @@ def generate_launch_description():
                 ),
             ]
         ),
+        launch_arguments={
+            "use_ap_namespace": LaunchConfiguration("use_ap_namespace"),
+        }.items(),
         condition=IfCondition(LaunchConfiguration("spawn_robot")),
     )
 
@@ -106,6 +109,11 @@ def generate_launch_description():
                 "namespace",
                 default_value="",
                 description="Robot namespace.",
+            ),
+            DeclareLaunchArgument(
+                "use_ap_namespace",
+                default_value="true",
+                description="If True, use namespaces for ardupilot clock sync (e.g. /ap/vN/clock)",
             ),
             DeclareLaunchArgument(
                 "use_gz_sim_server",

--- a/ardupilot_gz_bringup/launch/iris_runway.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_runway.launch.py
@@ -65,6 +65,9 @@ def generate_launch_description():
                 ),
             ]
         ),
+        launch_arguments={
+            "use_ap_namespace": LaunchConfiguration("use_ap_namespace"),
+        }.items(),
         condition=IfCondition(LaunchConfiguration("spawn_robot")),
     )
 
@@ -107,6 +110,11 @@ def generate_launch_description():
                 "namespace",
                 default_value="",
                 description="Robot namespace.",
+            ),
+            DeclareLaunchArgument(
+                "use_ap_namespace",
+                default_value="true",
+                description="If True, use namespaces for ardupilot clock sync (e.g. /ap/vN/clock)",
             ),
             DeclareLaunchArgument(
                 "use_gz_sim_server",

--- a/ardupilot_gz_bringup/launch/iris_warehouse.launch.py
+++ b/ardupilot_gz_bringup/launch/iris_warehouse.launch.py
@@ -68,6 +68,7 @@ def generate_launch_description():
         launch_arguments={
             "world_name": LaunchConfiguration("world_name"),
             "robot_name": LaunchConfiguration("robot_name"),
+            "use_ap_namespace": LaunchConfiguration("use_ap_namespace"),
         }.items(),
         condition=IfCondition(LaunchConfiguration("spawn_robot")),
     )
@@ -114,6 +115,11 @@ def generate_launch_description():
                 "namespace",
                 default_value="",
                 description="Robot namespace.",
+            ),
+            DeclareLaunchArgument(
+                "use_ap_namespace",
+                default_value="true",
+                description="If True, use namespaces for ardupilot clock sync (e.g. /ap/vN/clock)",
             ),
             DeclareLaunchArgument(
                 "world_name",

--- a/ardupilot_gz_bringup/launch/multiagent.launch.py
+++ b/ardupilot_gz_bringup/launch/multiagent.launch.py
@@ -174,6 +174,7 @@ def generate_launch_description():
                     "instance": str(instance),
                     "sysid": str(sysid),
                     "use_instance_dir": "True",
+                    "use_ap_namespace": "True",
                 }
             )
 

--- a/ardupilot_gz_bringup/launch/robots/alti_transition.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/alti_transition.launch.py
@@ -112,6 +112,7 @@ def generate_robot_launch_actions(context: LaunchContext, *args, **kwargs):
             "sysid": LaunchConfiguration("sysid"),
             "use_instance_dir": LaunchConfiguration("use_instance_dir"),
             "use_dds_agent": LaunchConfiguration("use_dds_agent"),
+            "use_ap_namespace": LaunchConfiguration("use_ap_namespace"),
         }.items(),
     )
 
@@ -200,6 +201,11 @@ def generate_launch_arguments() -> List[DeclareLaunchArgument]:
         # topic_tools_tf
         DeclareLaunchArgument(
             "use_gz_tf", default_value="true", description="Use Gazebo TF."
+        ),
+        DeclareLaunchArgument(
+            "use_ap_namespace",
+            default_value="true",
+            description="If True, use namespaces for ardupilot clock sync (e.g. /ap/vN/clock)",
         ),
         # bridge, spawn_robot
         DeclareLaunchArgument(

--- a/ardupilot_gz_bringup/launch/robots/iris.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris.launch.py
@@ -123,6 +123,7 @@ def generate_robot_launch_actions(context: LaunchContext, *args, **kwargs):
             "sysid": LaunchConfiguration("sysid"),
             "use_instance_dir": LaunchConfiguration("use_instance_dir"),
             "use_dds_agent": LaunchConfiguration("use_dds_agent"),
+            "use_ap_namespace": LaunchConfiguration("use_ap_namespace"),
         }.items(),
     )
 
@@ -211,6 +212,11 @@ def generate_launch_arguments() -> List[DeclareLaunchArgument]:
         # topic_tools_tf
         DeclareLaunchArgument(
             "use_gz_tf", default_value="true", description="Use Gazebo TF."
+        ),
+        DeclareLaunchArgument(
+            "use_ap_namespace",
+            default_value="true",
+            description="If True, use namespaces for ardupilot clock sync (e.g. /ap/vN/clock)",
         ),
         # Gazebo model launch arguments.
         DeclareLaunchArgument(

--- a/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/iris_lidar.launch.py
@@ -141,6 +141,7 @@ def generate_robot_launch_actions(context: LaunchContext, *args, **kwargs):
             "sysid": LaunchConfiguration("sysid"),
             "use_instance_dir": LaunchConfiguration("use_instance_dir"),
             "use_dds_agent": LaunchConfiguration("use_dds_agent"),
+            "use_ap_namespace": LaunchConfiguration("use_ap_namespace"),
         }.items(),
     )
 
@@ -229,6 +230,11 @@ def generate_launch_arguments() -> List[DeclareLaunchArgument]:
         # topic_tools_tf
         DeclareLaunchArgument(
             "use_gz_tf", default_value="true", description="Use Gazebo TF."
+        ),
+        DeclareLaunchArgument(
+            "use_ap_namespace",
+            default_value="true",
+            description="If True, use namespaces for ardupilot clock sync (e.g. /ap/vN/clock)",
         ),
         # bridge, spawn_robot
         DeclareLaunchArgument(

--- a/ardupilot_gz_bringup/launch/robots/robot.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/robot.launch.py
@@ -167,8 +167,35 @@ def launch_state_pub_with_bridge(
         condition=IfCondition(LaunchConfiguration("use_gz_tf")),
     )
 
+    # Relay clock to /ap/vN/clock for timesync with ardupilot_sitl
+    # Or the /ap/clock topic if not using namespaces
+    topic_tools_clock_namespace = Node(
+        package="topic_tools",
+        executable="relay",
+        namespace=namespace,
+        arguments=[
+            "clock",
+            f"/ap/v{instance+1}/clock",
+        ],
+        output="screen",
+        respawn=False,
+        condition=IfCondition(LaunchConfiguration("use_ap_namespace")),
+    )
+    topic_tools_clock = Node(
+        package="topic_tools",
+        executable="relay",
+        namespace=namespace,
+        arguments=[
+            "clock",
+            "/ap/clock",
+        ],
+        output="screen",
+        respawn=False,
+        condition=UnlessCondition(LaunchConfiguration("use_ap_namespace")),
+    )
+
     event = RegisterEventHandler(
-        OnProcessStart(target_action=bridge, on_start=[topic_tools_tf])
+        OnProcessStart(target_action=bridge, on_start=[topic_tools_tf, topic_tools_clock_namespace, topic_tools_clock])
     )
 
     return [robot_state_publisher, bridge, event]
@@ -333,6 +360,11 @@ def generate_launch_arguments() -> List[LaunchDescriptionEntity]:
         # topic_tools_tf
         DeclareLaunchArgument(
             "use_gz_tf", default_value="true", description="Use Gazebo TF."
+        ),
+        DeclareLaunchArgument(
+            "use_ap_namespace",
+            default_value="true",
+            description="If True, use namespaces for ardupilot clock sync (e.g. /ap/vN/clock)",
         ),
         DeclareLaunchArgument(
             "sdf_file",

--- a/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
+++ b/ardupilot_gz_bringup/launch/robots/wildthumper.launch.py
@@ -127,6 +127,7 @@ def generate_robot_launch_actions(context: LaunchContext, *args, **kwargs):
             "sysid": LaunchConfiguration("sysid"),
             "use_instance_dir": LaunchConfiguration("use_instance_dir"),
             "use_dds_agent": LaunchConfiguration("use_dds_agent"),
+            "use_ap_namespace": LaunchConfiguration("use_ap_namespace"),
         }.items(),
     )
 
@@ -215,6 +216,11 @@ def generate_launch_arguments() -> List[DeclareLaunchArgument]:
         # topic_tools_tf
         DeclareLaunchArgument(
             "use_gz_tf", default_value="true", description="Use Gazebo TF."
+        ),
+        DeclareLaunchArgument(
+            "use_ap_namespace",
+            default_value="true",
+            description="If True, use namespaces for ardupilot clock sync (e.g. /ap/vN/clock)",
         ),
         # bridge, spawn_robot
         DeclareLaunchArgument(

--- a/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
+++ b/ardupilot_gz_bringup/launch/wildthumper_playpen.launch.py
@@ -65,6 +65,9 @@ def generate_launch_description():
                 ),
             ]
         ),
+        launch_arguments={
+            "use_ap_namespace": LaunchConfiguration("use_ap_namespace"),
+        }.items(),
         condition=IfCondition(LaunchConfiguration("spawn_robot")),
     )
 
@@ -107,6 +110,11 @@ def generate_launch_description():
                 "namespace",
                 default_value="",
                 description="Robot namespace.",
+            ),
+            DeclareLaunchArgument(
+                "use_ap_namespace",
+                default_value="true",
+                description="If True, use namespaces for ardupilot clock sync (e.g. /ap/vN/clock)",
             ),
             DeclareLaunchArgument(
                 "use_gz_sim_server",


### PR DESCRIPTION
Companion PR for https://github.com/ArduPilot/ardupilot/pull/32303, adding in the ``use_ap_namespace`` argument. If set to true (default), Gazebo will relay the clock topic to ``/ap/v{instance+1}/clock``. If set to false it will be relayed to ``/ap/clock``.

This allows the Gazebo time to be sent to the correct ArduPilot topic, for clock sync.