### PR TITLE
Jazzy Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ by ArduPilot SITL with DDS support in Gazebo.
 
 The project is adapted from the [`ros_gz_project_template`](https://github.com/gazebosim/ros_gz_project_template) project.
 
+ROS2 Humble and Jazzy are supported
+
 ## Included packages
 
 * `ardupilot_gz_description` - Contains the SDFormat description of the simulated
@@ -19,7 +21,7 @@ The project is adapted from the [`ros_gz_project_template`](https://github.com/g
 
 ## Prerequisites
 
-- Install [ROS 2 Humble](https://docs.ros.org/en/humble/index.html)
+- Install [ROS 2 Jazzy](https://docs.ros.org/en/jazzy/index.html)
 - Install [Gazebo Harmonic (default)](https://gazebosim.org/docs/harmonic) or [Gazebo Jetty](https://gazebosim.org/docs/jetty)
 - Follow the [`Installing Build Dependencies`](https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_DDS#installing-build-dependencies) section of `AP_DDS`'s README
 
@@ -50,7 +52,7 @@ export GZ_VERSION=harmonic
 
 ```bash
 cd ~/ros2_ws
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 sudo apt update
 rosdep update
 rosdep install --from-paths src --ignore-src -y
@@ -85,7 +87,7 @@ source ~/ros2_ws/install/setup.sh
 ros2 launch ardupilot_gz_bringup iris_runway.launch.py rviz:=true use_gz_tf:=true
 ```
 
-#### 3. Launch a GCS (MAVPorxy)
+#### 3. Launch a GCS (MAVProxy)
 
 ```bash
 mavproxy.py --master udp:127.0.0.1:14550  --console --map

--- a/ros2_gz.repos
+++ b/ros2_gz.repos
@@ -18,12 +18,4 @@ repositories:
   micro_ros_agent:
     type: git
     url: https://github.com/micro-ROS/micro-ROS-Agent.git
-    version: humble
-  ros_gz:
-    type: git
-    url: https://github.com/gazebosim/ros_gz.git
-    version: humble
-  sdformat_urdf:
-    type: git
-    url: https://github.com/ros/sdformat_urdf.git
-    version: humble
+    version: jazzy


### PR DESCRIPTION
Updates to get ardupilot_gz working with ROS2 Jazzy.

I note that we currently have separate branches for ``main``, ``humble`` and ``jazzy``. Do we want to keep separate branches or just use ``main`` for everything? Note this PR assumes the latter, so I'll need to re-target it if we want the former.

I do note https://github.com/ArduPilot/ardupilot_gz/pull/62 attempted to automate this process - which would be useful.

Changes in this PR:
- Split out the repos file for separate Jazzy and Humble installs. Note that Jazzy does not need the ``ros_gz`` and ``sdformat_urdf`` source (as they come as precompiled packages), which makes things easier
- ~~One annoying issue I did encounter was the ``iris_lidar`` model required ``file://`` paths instead of ``package://`` paths to work correctly. Appears to be an issue with ``sdformat`` not being able to resolve ``package://`` paths. This is specific to the ``iris_with_lidar`` model, as it uses an ``<include>`` tag.~~

